### PR TITLE
[feature/452061-appsettings]

### DIFF
--- a/src/EPR.RegulatorService.Frontend.Web/appsettings.json
+++ b/src/EPR.RegulatorService.Frontend.Web/appsettings.json
@@ -144,6 +144,6 @@
     "ManageApprovedUsers": false,
     "PomDataPeriodAndTime": true,
     "RegistrationDataPeriodAndTime": true,
-    "ManageRegistrationSubmissions": true
+    "ManageRegistrationSubmissions": false
   }
 }


### PR DESCRIPTION
Disabled the ManageRegistrationSubmissions feature flag in appsettings.

This is under the instructions of Peter Laker to ensure that other environments aren't able to access this feature. We have added a key to the environment variables in Azure Portal 5411 which is set to true.

The QA test here is to ensure that the feature is still available.