### PR TITLE
Feature/459928 change submission year to relevant year

### DIFF
--- a/src/EPR.RegulatorService.Frontend.Core/Models/RegistrationSubmissions/RegistrationSubmissionsOrganisationPaymentDetails.cs
+++ b/src/EPR.RegulatorService.Frontend.Core/Models/RegistrationSubmissions/RegistrationSubmissionsOrganisationPaymentDetails.cs
@@ -12,4 +12,6 @@ public class RegistrationSubmissionsOrganisationPaymentDetails
     public decimal PreviousPaymentsReceived { get; set; }
 
     public decimal TotalOutstanding => TotalChargeableItems - PreviousPaymentsReceived;
+
+    public decimal? OfflinePaymentAmount { get; set; }
 }

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/Controllers/RegistrationSubmissionsControllerTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/Controllers/RegistrationSubmissionsControllerTests.cs
@@ -1,8 +1,5 @@
 namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
 {
-    using System.ComponentModel.DataAnnotations;
-
-    using EPR.RegulatorService.Frontend.Core.Enums;
     using EPR.RegulatorService.Frontend.Core.Models;
     using EPR.RegulatorService.Frontend.Core.Models.RegistrationSubmissions;
     using EPR.RegulatorService.Frontend.Core.Sessions;
@@ -13,7 +10,9 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
 
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Routing;
     using Microsoft.Extensions.Logging;
+
     using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
 
     [TestClass]
@@ -154,7 +153,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             };
 
             SetupJourneySession(latestFilterChoices, null);
-        
+
             // Act
             var result = await _controller.RegistrationSubmissions(null);
 
@@ -233,7 +232,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             int expected_page_number = 2;
 
             RegistrationSubmissionsFilterModel emptyFilterChoices = new()
-            {};
+            { };
 
             RegistrationSubmissionsFilterModel latestFilterChoices = new()
             {
@@ -413,7 +412,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
         public async Task PostTo_RegistrationSubmissions_Logs_Error_When_Exception_Received()
         {
             _mockSessionManager.Setup(x => x.GetSessionAsync(It.IsAny<ISession>())).Throws(new Exception("Test"));
-            var result = await _controller.RegistrationSubmissions(null,null);
+            var result = await _controller.RegistrationSubmissions(null, null);
             Assert.IsNotNull(result);
             result.Should().BeOfType<RedirectToActionResult>();
             (result as RedirectToActionResult).ActionName.Should().Be(PagePath.Error);
@@ -422,7 +421,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
                             It.Is<LogLevel>(logLevel => logLevel == LogLevel.Error),
                             It.Is<EventId>((eid) => eid == 1001),
                             It.IsAny<It.IsAnyType>(),
-                            It.Is<Exception>((v, t)=> v.ToString().Contains("Test")),
+                            It.Is<Exception>((v, t) => v.ToString().Contains("Test")),
                             It.IsAny<Func<It.IsAnyType, Exception, string>>()),
                         Times.Once);
         }
@@ -449,58 +448,215 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
         #endregion Session Models and Filter states between gets and posts
         #endregion RegistrationSubmissions
 
+        #region GrantRegistrationSubmission
+
+        [TestMethod]
+        public async Task GrantRegistrationSubmission_SessionDataError_ReturnsPageNotFOund()
+        {
+            // Act
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
+
+            _controller.Url = mockUrlHelper.Object;
+            var result = await _controller.GrantRegistrationSubmission(Guid.NewGuid());
+
+            // Assert
+            var viewResult = result as RedirectToActionResult;
+            Assert.IsNotNull(viewResult, "Result should be of type ViewResult.");
+
+            Assert.AreEqual(PagePath.PageNotFound, viewResult.ActionName); // Ensure the user is redirected to the correct URL 
+        }
+
+        [TestMethod]
+        public async Task GrantRegistrationSubmission_ReturnsView_WithCorrectModel()
+        {
+            // Arrange 
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
+
+            // Act
+            _controller.Url = mockUrlHelper.Object;
+            var result = await _controller.GrantRegistrationSubmission(id) as ViewResult;
+
+            // Assert
+            Assert.IsNotNull(result, "Result should be a ViewResult when ModelState is invalid.");
+            Assert.AreEqual(nameof(_controller.GrantRegistrationSubmission), result.ViewName, "The view name should match the action name.");
+
+            // Verify that a back link is set with the expected format, including a GUID
+            string backLink = _controller.ViewData["BackLinkToDisplay"] as string;
+            Assert.IsNotNull(backLink, "BackLinkToDisplay should be set in ViewData.");
+            StringAssert.StartsWith(backLink, $"/regulators/{PagePath.RegistrationSubmissionDetails}/", "Back link should start with the expected URL.");
+
+            // Check that the back link contains a valid GUID at the end
+            string[] segments = backLink.Split('/');
+            Assert.IsTrue(Guid.TryParse(segments[^1], out _), "Back link should contain a valid GUID.");
+        }
+
+        #endregion GrantRegistrationSubmission
+
         #region QueryRegistrationSubmission
+
+        [TestMethod]
+        public async Task QueryRegistrationSubmission_Post_SessionDataError_ReturnsPageNotFOund()
+        {
+            // Act
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
+            var expectedViewModel = new QueryRegistrationSubmissionViewModel
+            {
+                OrganisationId = Guid.NewGuid(),
+                Query = "query provided"
+            };
+
+            _controller.Url = mockUrlHelper.Object;
+            var result = await _controller.QueryRegistrationSubmission(expectedViewModel);
+
+            // Assert
+            var viewResult = result as RedirectToActionResult;
+            Assert.IsNotNull(viewResult, "Result should be of type ViewResult.");
+
+            Assert.AreEqual(PagePath.PageNotFound, viewResult.ActionName); // Ensure the user is redirected to the correct URL 
+        }
+
+        [TestMethod]
+        public async Task QueryRegistrationSubmission_SessionDataError_ReturnsPageNotFOund()
+        {
+            // Act
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
+
+            _controller.Url = mockUrlHelper.Object;
+            var result = await _controller.QueryRegistrationSubmission(Guid.NewGuid());
+
+            // Assert
+            var viewResult = result as RedirectToActionResult;
+            Assert.IsNotNull(viewResult, "Result should be of type ViewResult.");
+
+            Assert.AreEqual(PagePath.PageNotFound, viewResult.ActionName); // Ensure the user is redirected to the correct URL 
+        }
 
         [TestMethod]
         public async Task QueryRegistrationSubmission_ReturnsView_WithCorrectModel()
         {
-            // Arrange
-            string expectedBacktoAllSubmissionsUrl = PagePath.RegistrationSubmissionsRoute;
+            // Arrange 
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
 
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
             var expectedViewModel = new QueryRegistrationSubmissionViewModel
             {
-                BackToAllSubmissionsUrl = expectedBacktoAllSubmissionsUrl
+                OrganisationId = id,
+                Query = "query provided"
             };
 
             // Act
-            var result = await _controller.QueryRegistrationSubmission() as ViewResult;
+            _controller.Url = mockUrlHelper.Object;
+            var result = await _controller.QueryRegistrationSubmission(id) as ViewResult;
 
             // Assert
-            Assert.IsNotNull(result);
-            Assert.AreEqual(nameof(_controller.QueryRegistrationSubmission), result.ViewName);
-            Assert.IsInstanceOfType(result.Model, typeof(QueryRegistrationSubmissionViewModel));
-            var resultViewModel = result.Model as QueryRegistrationSubmissionViewModel;
-            Assert.AreEqual(expectedViewModel.Query, resultViewModel.Query);
-            Assert.AreEqual(expectedViewModel.BackToAllSubmissionsUrl, resultViewModel.BackToAllSubmissionsUrl);
+            Assert.IsNotNull(result, "Result should be a ViewResult when ModelState is invalid.");
+            Assert.AreEqual(nameof(_controller.QueryRegistrationSubmission), result.ViewName, "The view name should match the action name.");
+
+            // Verify that a back link is set with the expected format, including a GUID
+            string backLink = _controller.ViewData["BackLinkToDisplay"] as string;
+            Assert.IsNotNull(backLink, "BackLinkToDisplay should be set in ViewData.");
+            StringAssert.StartsWith(backLink, $"/regulators/{PagePath.RegistrationSubmissionDetails}/", "Back link should start with the expected URL.");
+
+            // Check that the back link contains a valid GUID at the end
+            string[] segments = backLink.Split('/');
+            Assert.IsTrue(Guid.TryParse(segments[^1], out _), "Back link should contain a valid GUID.");
         }
 
         [TestMethod]
         public async Task QueryRegistrationSubmission_SetsCorrectBackLinkInViewData()
         {
             // Act
-            var result = await _controller.QueryRegistrationSubmission();
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
+            var expectedViewModel = new QueryRegistrationSubmissionViewModel
+            {
+                OrganisationId = id,
+                Query = "query provided"
+            };
+
+            _controller.Url = mockUrlHelper.Object;
+            var result = await _controller.QueryRegistrationSubmission(expectedViewModel);
 
             // Assert
-            var viewResult = result as ViewResult;
+            var viewResult = result as RedirectToActionResult;
             Assert.IsNotNull(viewResult, "Result should be of type ViewResult.");
 
-            string backLink = _controller.ViewData["BackLinkToDisplay"] as string;
-            Assert.IsNotNull(backLink, "BackLinkToDisplay should be set in ViewData.");
-            StringAssert.StartsWith(backLink, $"/regulators/{PagePath.RegistrationSubmissionDetails}/", "Back link should start with the expected URL.");
-
-            // Extract the GUID part using indexing and check for validity
-            string[] segments = backLink.Split('/');
-            Assert.IsNotNull(segments, "The back link should contain URL segments.");
-            Assert.IsTrue(Guid.TryParse(segments[^1], out _), "Back link should contain a valid GUID.");
+            Assert.AreEqual(PagePath.RegistrationSubmissionsAction, viewResult.ActionName); // Ensure the user is redirected to the correct URL 
         }
 
         [TestMethod]
         public async Task QueryRegistrationSubmission_Post_ReturnsView_WhenModelStateIsInvalid()
         {
             // Arrange
-            var model = new QueryRegistrationSubmissionViewModel();
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
+
+            var model = new QueryRegistrationSubmissionViewModel
+            {
+                OrganisationId = id
+            };
 
             // Simulate an error in ModelState
+            _controller.Url = mockUrlHelper.Object;
             _controller.ModelState.AddModelError("TestError", "Model state is invalid");
 
             // Act
@@ -529,29 +685,64 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
         public async Task QueryRegistrationSubmission_Post_ReturnsSuccessAndRedirectsCorrectly_WhenQueryIsValid()
         {
             // Arrange
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
+
             var model = new QueryRegistrationSubmissionViewModel
             {
+                OrganisationId = id,
                 Query = "Valid query within 400 characters." // Valid input
             };
 
             // Act
-            var result = await _controller.QueryRegistrationSubmission(model) as RedirectResult;
+            _controller.Url = mockUrlHelper.Object;
+            var result = await _controller.QueryRegistrationSubmission(model) as RedirectToActionResult;
 
             // Assert
             Assert.IsNotNull(result); // Ensure the result is not null
-            Assert.AreEqual(PagePath.RegistrationSubmissionsRoute, result.Url); // Ensure the user is redirected to the correct URL
+            Assert.AreEqual(PagePath.RegistrationSubmissionsAction, result.ActionName); // Ensure the user is redirected to the correct URL
+        }
+
+
+        private static Mock<IUrlHelper> CreateUrlHelper(Guid id, string locationUrl)
+        {
+            var mockUrlHelper = new Mock<IUrlHelper>();
+            mockUrlHelper
+                .Setup(x => x.RouteUrl(It.IsAny<UrlRouteContext>()))
+                .Returns(locationUrl);
+            return mockUrlHelper;
         }
 
         [TestMethod]
         public async Task QueryRegistrationSubmission_Post_ReturnsExpectedError_WhenInputIsGreaterThan400()
         {
             // Arrange
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
             var model = new QueryRegistrationSubmissionViewModel
             {
+                OrganisationId = id,
                 Query = new string('A', 401) // Exceeds 400 character limit
             };
 
             // Simulate model state error for the Query property
+            _controller.Url = mockUrlHelper.Object;
             _controller.ModelState.AddModelError(nameof(model.Query), "Reason for querying application must be 400 characters or less");
 
             // Act
@@ -570,7 +761,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             // Verify that a back link is set with the expected format, including a GUID
             string backLink = _controller.ViewData["BackLinkToDisplay"] as string;
             Assert.IsNotNull(backLink, "BackLinkToDisplay should be set in ViewData.");
-            StringAssert.StartsWith(backLink, $"/regulators/{PagePath.RegistrationSubmissionDetails}/", "Back link should start with the expected URL.");
+            StringAssert.StartsWith(backLink, locationUrl, "Back link should start with the expected URL.");
 
             // Check that the back link contains a valid GUID at the end
             string[] segments = backLink.Split('/');
@@ -581,12 +772,24 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
         public async Task QueryRegistrationSubmission_Post_ReturnsViewWithErrors_WhenNoQueryIsProvided()
         {
             // Arrange
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
             var model = new QueryRegistrationSubmissionViewModel
             {
+                OrganisationId = id,
                 Query = null // No query provided
             };
 
             // Simulate the required field validation error for the Query property
+            _controller.Url = mockUrlHelper.Object;
             _controller.ModelState.AddModelError(nameof(model.Query), "Enter the reason you are querying this registration application");
 
             // Act
@@ -617,18 +820,80 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
         #region RejectRegistrationSubmission
 
         [TestMethod]
-        public async Task RejectRegistrationSubmission_ReturnsView_WithCorrectModel()
+        public async Task RejectRegistrationSubmission_SessionDataError_ReturnsPageNotFOund()
         {
-            // Arrange
-            string expectedBacktoAllSubmissionsUrl = PagePath.RegistrationSubmissionsRoute;
+            // Act
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
 
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
+
+            _controller.Url = mockUrlHelper.Object;
+            var result = await _controller.RejectRegistrationSubmission(Guid.NewGuid());
+
+            // Assert
+            var viewResult = result as RedirectToActionResult;
+            Assert.IsNotNull(viewResult, "Result should be of type ViewResult.");
+
+            Assert.AreEqual(PagePath.PageNotFound, viewResult.ActionName); // Ensure the user is redirected to the correct URL 
+        }
+        [TestMethod]
+        public async Task RejectRegistrationSubmission_Post_SessionDataError_ReturnsPageNotFOund()
+        {
+            // Act
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
             var expectedViewModel = new RejectRegistrationSubmissionViewModel
             {
-                BackToAllSubmissionsUrl = expectedBacktoAllSubmissionsUrl
+                OrganisationId = Guid.NewGuid()
+            };
+
+            _controller.Url = mockUrlHelper.Object;
+            var result = await _controller.RejectRegistrationSubmission(expectedViewModel);
+
+            // Assert
+            var viewResult = result as RedirectToActionResult;
+            Assert.IsNotNull(viewResult, "Result should be of type ViewResult.");
+
+            Assert.AreEqual(PagePath.PageNotFound, viewResult.ActionName); // Ensure the user is redirected to the correct URL 
+        }
+
+        [TestMethod]
+        public async Task RejectRegistrationSubmission_ReturnsView_WithCorrectModel()
+        {
+            // Arrange 
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
+            var expectedViewModel = new RejectRegistrationSubmissionViewModel
+            {
+                OrganisationId = id
             };
 
             // Act
-            var result = await _controller.RejectRegistrationSubmission() as ViewResult;
+            _controller.Url = mockUrlHelper.Object;
+            var result = await _controller.RejectRegistrationSubmission(id) as ViewResult;
 
             // Assert
             Assert.IsNotNull(result);
@@ -636,14 +901,27 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             Assert.IsInstanceOfType(result.Model, typeof(RejectRegistrationSubmissionViewModel));
             var resultViewModel = result.Model as RejectRegistrationSubmissionViewModel;
             Assert.AreEqual(expectedViewModel.RejectReason, resultViewModel.RejectReason);
-            Assert.AreEqual(expectedViewModel.BackToAllSubmissionsUrl, resultViewModel.BackToAllSubmissionsUrl);
+            Assert.AreEqual(id, resultViewModel.OrganisationId);
         }
 
         [TestMethod]
         public async Task RejectRegistrationSubmission_ShouldSetCorrectBackLink()
         {
+            // Arrange
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
+
             // Act
-            var result = await _controller.RejectRegistrationSubmission();
+            _controller.Url = mockUrlHelper.Object;
+            var result = await _controller.RejectRegistrationSubmission(id);
 
             // Assert
             var viewResult = result as ViewResult;
@@ -663,9 +941,23 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
         public async Task RejectRegistrationSubmission_Post_ReturnsView_WhenModelStateIsInvalid()
         {
             // Arrange
-            var model = new RejectRegistrationSubmissionViewModel();
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
+            var model = new RejectRegistrationSubmissionViewModel
+            {
+                OrganisationId = id
+            };
 
             // Simulate an error in ModelState
+            _controller.Url = mockUrlHelper.Object;
             _controller.ModelState.AddModelError("TestError", "Model state is invalid");
 
             // Act
@@ -694,12 +986,24 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
         public async Task RejectRegistrationSubmission_Post_ReturnsSuccessAndRedirectsCorrectly_WhenRejectionReasonIsValid()
         {
             // Arrange
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
             var model = new RejectRegistrationSubmissionViewModel
             {
+                OrganisationId = id,
                 RejectReason = "Valid rejection reason within 400 characters." // Valid input
             };
 
             // Act
+            _controller.Url = mockUrlHelper.Object;
             var result = await _controller.RejectRegistrationSubmission(model) as RedirectResult;
 
             // Assert
@@ -711,8 +1015,19 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
         public async Task RejectRegistrationSubmission_Post_ReturnsExpectedError_WhenInputIsGreaterThan400()
         {
             // Arrange
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
             var model = new RejectRegistrationSubmissionViewModel
             {
+                OrganisationId = id,
                 RejectReason = new string('A', 401) // Exceeds 400 character limit
             };
 
@@ -720,6 +1035,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             _controller.ModelState.AddModelError(nameof(model.RejectReason), "Reason for rejecting application must be 400 characters or less");
 
             // Act
+            _controller.Url = mockUrlHelper.Object;
             var result = await _controller.RejectRegistrationSubmission(model) as ViewResult;
 
             // Assert
@@ -746,8 +1062,19 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
         public async Task RejectRegistrationSubmission_Post_ReturnsExpectedError_WhenNoRejectionReasonIsProvided()
         {
             // Arrange
+            var id = Guid.NewGuid();
+            string locationUrl = $"/regulators/{PagePath.RegistrationSubmissionDetails}/{id}";
+
+            var mockUrlHelper = CreateUrlHelper(id, locationUrl);
+
+            var detailsModel = GenerateTestSubmissionDetailsViewModel(id);
+            _journeySession.RegulatorRegistrationSubmissionSession = new RegulatorRegistrationSubmissionSession()
+            {
+                SelectedRegistration = detailsModel
+            };
             var model = new RejectRegistrationSubmissionViewModel
             {
+                OrganisationId = id,
                 RejectReason = null // No rejection reason provided
             };
 
@@ -755,6 +1082,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             _controller.ModelState.AddModelError(nameof(model.RejectReason), "Enter the reason you are rejecting this registration application");
 
             // Act
+            _controller.Url = mockUrlHelper.Object;
             var result = await _controller.RejectRegistrationSubmission(model) as ViewResult;
 
             // Assert
@@ -878,7 +1206,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
         }
 
         [TestMethod]
-       public async Task RegistrationSubmissionDetails_SetsCorrectBackLink()
+        public async Task RegistrationSubmissionDetails_SetsCorrectBackLink()
         {
             // Arrange
             var organisationId = Guid.NewGuid();
@@ -895,25 +1223,22 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             AssertBackLink(result, $"/regulators/{PagePath.RegistrationSubmissionsRoute}");
         }
 
-        /// <summary>
-        /// This test will change when we connect to the next page in the journey
-        /// </summary>
         [TestMethod]
-        public async Task SubmitOfflinePayment_Post_RedirectsToRegistrationSubmissions_WhenCalled_With_Valid_Model()
+        public async Task SubmitOfflinePayment_Post_RedirectsToConfirmOfflinePaymentSubmission_WhenCalled_With_Valid_Model()
         {
             // Arrange
-            var model = GenerateValidPaymentDetailsViewModel() ;
+            var model = GenerateValidPaymentDetailsViewModel();
             var detailsModel = GenerateTestSubmissionDetailsViewModel(Guid.NewGuid());
 
             _journeySession.RegulatorRegistrationSubmissionSession.SelectedRegistration = detailsModel;
             _facadeServiceMock.Setup(x => x.GetRegistrationSubmissionDetails(It.IsAny<Guid>())).Returns(detailsModel);
 
             // Act
-            var result = await _controller.SubmitOfflinePayment(model, detailsModel.OrganisationId) as ViewResult;
+            var result = await _controller.SubmitOfflinePayment(model, detailsModel.OrganisationId);
 
             // Assert
             Assert.IsNotNull(result);
-            result.ViewName.Should().Be("RegistrationSubmissionDetails");
+            Assert.IsInstanceOfType(result, typeof(RedirectResult));
             _controller.ModelState.IsValid.Should().BeTrue();
         }
 
@@ -952,7 +1277,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             _controller.ModelState.AddModelError("OfflinePayment", "The field is required.");
 
             // Act
-            var result = await _controller.SubmitOfflinePayment(model, detailsModel.OrganisationId) ;
+            var result = await _controller.SubmitOfflinePayment(model, detailsModel.OrganisationId);
             var viewResult = result as ViewResult;
 
             // Assert
@@ -1035,5 +1360,232 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             Assert.AreEqual(PagePath.RegistrationSubmissionsRoute, redirectResult.RouteValues["backLink"]);
         }
         #endregion Page Not Found
+
+        #region ConfirmOfflinePaymentSubmission
+
+        [TestMethod]
+        public async Task ConfirmOfflinePaymentSubmission_NullOrganisationId_RedirectsToPageNotFound()
+        {
+            // Act
+            var result = await _controller.ConfirmOfflinePaymentSubmission((Guid?)null);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(RedirectToActionResult));
+            var redirectResult = result as RedirectToActionResult;
+            Assert.AreEqual("PageNotFound", redirectResult.ActionName);
+            Assert.AreEqual("RegistrationSubmissions", redirectResult.ControllerName);
+        }
+
+        [TestMethod]
+        public async Task ConfirmOfflinePaymentSubmission_RedirectsToPageNotFound_ForAnInvalidOrganisationId()
+        {
+            // Arrange
+            var invalidOrganisationId = Guid.NewGuid();
+            SetupJourneySession(null, null); // No valid session with matching organisation
+
+            // Act
+            var result = await _controller.ConfirmOfflinePaymentSubmission(invalidOrganisationId);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(RedirectToActionResult));
+            var redirectResult = result as RedirectToActionResult;
+            Assert.AreEqual("PageNotFound", redirectResult.ActionName);
+            Assert.AreEqual("RegistrationSubmissions", redirectResult.ControllerName);
+        }
+
+        [TestMethod]
+        public async Task ConfirmOfflinePaymentSubmission_RedirectsToPageNotFound_ForAnEmptyOfflinePayment()
+        {
+            // Arrange
+            var organisationId = Guid.NewGuid();
+            var submissionDetails = GenerateTestSubmissionDetailsViewModel(organisationId);
+            submissionDetails.PaymentDetails.OfflinePayment = string.Empty; // Simulate empty offline payment
+            SetupJourneySession(null, submissionDetails);
+
+            // Act
+            var result = await _controller.ConfirmOfflinePaymentSubmission(organisationId);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(RedirectToActionResult));
+            var redirectResult = result as RedirectToActionResult;
+            Assert.AreEqual("PageNotFound", redirectResult.ActionName);
+            Assert.AreEqual("RegistrationSubmissions", redirectResult.ControllerName);
+        }
+
+        [TestMethod]
+        public async Task ConfirmOfflinePaymentSubmission_SetsCorrectBackLink()
+        {
+            // Arrange
+            var organisationId = Guid.NewGuid();
+            var submissionDetails = GenerateTestSubmissionDetailsViewModel(organisationId);
+            submissionDetails.PaymentDetails = GenerateValidPaymentDetailsViewModel();
+            SetupJourneySession(null, submissionDetails);
+
+            string expectedBackLink = "/expected/backlink/url";
+
+            // Act
+            var result = await _controller.ConfirmOfflinePaymentSubmission(organisationId);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(ViewResult));
+            var viewResult = result as ViewResult;
+
+            // Check if backlink is correctly set in ViewData
+            AssertBackLink(viewResult, expectedBackLink);
+        }
+
+        [TestMethod]
+        public async Task ConfirmOfflinePaymentSubmission_ReturnsViewWithCorrectModel_ForAValidOrganisationIdAndOfflinePayment()
+        {
+            // Arrange
+            var organisationId = Guid.NewGuid();
+            var submissionDetails = GenerateTestSubmissionDetailsViewModel(organisationId);
+            submissionDetails.PaymentDetails = GenerateValidPaymentDetailsViewModel();
+            SetupJourneySession(null, submissionDetails);
+
+            var expectedViewModel = new ConfirmOfflinePaymentSubmissionViewModel
+            {
+                OrganisationId = organisationId,
+                IsOfflinePaymentConfirmed = null,
+                OfflinePaymentAmount = "10.00"
+            };
+
+            // Act
+            var result = await _controller.ConfirmOfflinePaymentSubmission(organisationId);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(ViewResult));
+            var viewResult = result as ViewResult;
+            Assert.AreEqual("ConfirmOfflinePaymentSubmission", viewResult.ViewName);
+
+            var model = viewResult.Model as ConfirmOfflinePaymentSubmissionViewModel;
+            Assert.IsNotNull(model);
+            Assert.AreEqual(expectedViewModel.OrganisationId, model.OrganisationId);
+            Assert.AreEqual(submissionDetails.PaymentDetails.OfflinePayment, model.OfflinePaymentAmount);
+            Assert.AreEqual(expectedViewModel.IsOfflinePaymentConfirmed, model.IsOfflinePaymentConfirmed);
+
+            // Verify backlink setup
+            AssertBackLink(viewResult, "/expected/backlink/url");
+        }
+
+        [TestMethod]
+        public async Task ConfirmOfflinePaymentSubmission_RedirectsToSubmissionDetails_ValidOrganisationIdAndValidModel()
+        {
+            // Arrange
+            var organisationId = Guid.NewGuid();
+            var submissionDetails = GenerateTestSubmissionDetailsViewModel(organisationId);
+            submissionDetails.PaymentDetails = GenerateValidPaymentDetailsViewModel();
+            SetupJourneySession(null, submissionDetails);
+
+            var model = new ConfirmOfflinePaymentSubmissionViewModel
+            {
+                OrganisationId = organisationId,
+                OfflinePaymentAmount = submissionDetails.PaymentDetails.OfflinePayment, // Valid amount
+                IsOfflinePaymentConfirmed = true
+            };
+
+            // Set up session mock
+            SetupJourneySession(null, submissionDetails);
+
+            // Act
+            var result = await _controller.ConfirmOfflinePaymentSubmission(model);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(RedirectResult));
+
+            var redirectResult = result as RedirectResult;
+
+            // Veryify the redirect URL
+            string expectedRedirectUrl = _controller.Url.RouteUrl("SubmissionDetails", new { organisationId });
+            Assert.AreEqual(expectedRedirectUrl, redirectResult.Url);
+        }
+
+        [TestMethod]
+        public async Task ConfirmOfflinePaymentSubmission_RedirectsToPageNotFound_WhenOfflinePaymentAmountIsEmpty()
+        {
+            // Arrange
+            var organisationId = Guid.NewGuid();
+            var submissionDetails = GenerateTestSubmissionDetailsViewModel(organisationId);
+            submissionDetails.PaymentDetails = new PaymentDetailsViewModel();
+            SetupJourneySession(null, submissionDetails);
+
+            var model = new ConfirmOfflinePaymentSubmissionViewModel
+            {
+                OrganisationId = organisationId,
+                OfflinePaymentAmount = submissionDetails.PaymentDetails.OfflinePayment, // Amount is null here
+                IsOfflinePaymentConfirmed = false
+            };
+
+            // Act
+            var result = await _controller.ConfirmOfflinePaymentSubmission(model);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(RedirectToActionResult));
+
+            var redirectToActionResult = result as RedirectToActionResult;
+
+            // Veryify the correct redirect
+            Assert.AreEqual("RegistrationSubmissions", redirectToActionResult.ControllerName);
+            Assert.AreEqual("PageNotFound", redirectToActionResult.ActionName);
+        }
+
+        [TestMethod]
+        public async Task ConfirmOfflinePaymentSubmission_Post_ReturnsView_WhenModelStateIsInvalid()
+        {
+            // Arrange
+            var organisationId = Guid.NewGuid();
+            var submissionDetails = GenerateTestSubmissionDetailsViewModel(organisationId);
+            submissionDetails.PaymentDetails = GenerateValidPaymentDetailsViewModel();
+            SetupJourneySession(null, submissionDetails);
+
+            var model = new ConfirmOfflinePaymentSubmissionViewModel
+            {
+                OrganisationId = organisationId,
+                OfflinePaymentAmount = submissionDetails.PaymentDetails.OfflinePayment
+            };
+
+            // Simulate an error in ModelState
+            _controller.ModelState.AddModelError("TestError", "Model state is invalid");
+
+            // Set up session mock
+            SetupJourneySession(null, submissionDetails);
+
+            // Act
+            var result = await _controller.ConfirmOfflinePaymentSubmission(model) as ViewResult;
+
+            // Assert
+            Assert.IsNotNull(result, "Result should be a ViewResult when ModelState is invalid.");
+            Assert.AreEqual(nameof(_controller.ConfirmOfflinePaymentSubmission), result.ViewName, "The view name should match the action name.");
+            Assert.AreEqual(model, result.Model, "The returned model should match the input model.");
+
+            // Verify that ModelState has errors
+            Assert.IsTrue(_controller.ModelState.ErrorCount > 0, "ModelState should contain errors.");
+            Assert.AreEqual("Model state is invalid", _controller.ModelState["TestError"].Errors[0].ErrorMessage, "The error message should match the expected message.");
+        }
+
+        [TestMethod]
+        public async Task ConfirmOfflinePaymentSubmission_RedirectsToPageNotFound_WhenOrgsanisationIdIsEmpty()
+        {
+            // Arrange
+            var model = new ConfirmOfflinePaymentSubmissionViewModel();
+            SetupJourneySession(null, null);
+
+            // Act
+            var result = await _controller.ConfirmOfflinePaymentSubmission(model);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(RedirectToActionResult));
+
+            var redirectToActionResult = result as RedirectToActionResult;
+
+            // Veryify the correct redirect
+            Assert.AreEqual("RegistrationSubmissions", redirectToActionResult.ControllerName);
+            Assert.AreEqual("PageNotFound", redirectToActionResult.ActionName);
+        }
+
+        #endregion
     }
 }

--- a/src/EPR.RegulatorService.Frontend.Web/Constants/PagePath.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Constants/PagePath.cs
@@ -38,9 +38,11 @@ public static class PagePath
     public const string OrganisationDetailsFileDownloadSecurityWarning = "organisation-details-file-download-security-warning";
     public const string RegistrationSubmissionsRoute = "manage-registration-submissions";
     public const string RegistrationSubmissionsAction = "RegistrationSubmissions";
+    public const string GrantRegistrationSubmission = "manage-registration-submissions-grant";
     public const string QueryRegistrationSubmission = "manage-registration-submissions-query";
     public const string RejectRegistrationSubmission = "manage-registration-submissions-reject";
     public const string RegistrationSubmissionDetails = "registration-submission-details";
+    public const string ConfirmOfflinePaymentSubmission = "confirm-offline-payment-submission";
 
     // Non journey paths
     public const string Accessibility = "accessibility";

--- a/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController.cs
@@ -1,10 +1,7 @@
-using System.Drawing.Drawing2D;
 using System.Diagnostics;
 
 using EPR.Common.Authorization.Constants;
-using EPR.RegulatorService.Frontend.Core.Enums;
-using EPR.RegulatorService.Frontend.Core.Extensions;
-using EPR.RegulatorService.Frontend.Core.Models;
+using EPR.RegulatorService.Frontend.Core.Services;
 using EPR.RegulatorService.Frontend.Core.Sessions;
 using EPR.RegulatorService.Frontend.Web.Configs;
 using EPR.RegulatorService.Frontend.Web.Constants;
@@ -18,8 +15,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement.Mvc;
 
 using ServiceRole = EPR.RegulatorService.Frontend.Core.Enums.ServiceRole;
-using EPR.RegulatorService.Frontend.Core.Models.RegistrationSubmissions;
-using EPR.RegulatorService.Frontend.Core.Services;
 
 namespace EPR.RegulatorService.Frontend.Web.Controllers.RegistrationSubmissions;
 
@@ -136,7 +131,7 @@ public partial class RegistrationSubmissionsController(
 
     [HttpPost]
     [Route(PagePath.RegistrationSubmissionDetails + "/{organisationId:guid}", Name = "SubmitPaymentInfo")]
-    public async Task<IActionResult> SubmitOfflinePayment([FromForm] PaymentDetailsViewModel model, [FromRoute] Guid? organisationid)
+    public async Task<IActionResult> SubmitOfflinePayment([FromForm] PaymentDetailsViewModel paymentDetailsViewModel, [FromRoute] Guid? organisationid)
     {
         _currentSession = await _sessionManager.GetSessionAsync(HttpContext.Session);
 
@@ -145,56 +140,108 @@ public partial class RegistrationSubmissionsController(
             return RedirectToAction(PagePath.PageNotFound, "RegistrationSubmissions");
         }
 
-        existingModel.PaymentDetails = model;
-
         if (!ModelState.IsValid)
         {
             return View(nameof(RegistrationSubmissionDetails), existingModel);
         }
 
-        model.EnsureTwoDecimalPlaces();
+        paymentDetailsViewModel.EnsureTwoDecimalPlaces();
 
-        // otherwise we will redirect to the confirmation page
-        return View(nameof(RegistrationSubmissionDetails), existingModel);
+        existingModel.PaymentDetails.OfflinePayment = paymentDetailsViewModel.OfflinePayment;
+
+        _currentSession.RegulatorRegistrationSubmissionSession.SelectedRegistration = existingModel;
+
+        await SaveSessionAndJourney(
+            _currentSession.RegulatorRegistrationSubmissionSession,
+            PagePath.RegistrationSubmissionsRoute,
+            PagePath.RegistrationSubmissionsRoute);
+
+        return Redirect(Url.RouteUrl("ConfirmOfflinePaymentSubmission", new { existingModel.OrganisationId }));
     }
 
-    [HttpGet]
-    [Route(PagePath.QueryRegistrationSubmission)]
-    public async Task<IActionResult> QueryRegistrationSubmission()
+    [HttpGet] 
+    [Route(PagePath.GrantRegistrationSubmission + "/{organisationId:guid}", Name = "GrantRegistrationSubmission")]
+    public async Task<IActionResult> GrantRegistrationSubmission(Guid? organisationId)
     {
         _currentSession = await _sessionManager.GetSessionAsync(HttpContext.Session);
 
-        SetBackLink($"{PagePath.RegistrationSubmissionDetails}/{Guid.NewGuid()}");
+        if (!GetOrRejectProvidedOrganisationId(organisationId, out RegistrationSubmissionDetailsViewModel existingModel))
+        {
+            return RedirectToAction(PagePath.PageNotFound, "RegistrationSubmissions");
+        }
 
-        var model = new QueryRegistrationSubmissionViewModel();
+        SetBackLink(Url.RouteUrl("SubmissionDetails", new { organisationId }), false);
 
-        return View(nameof(QueryRegistrationSubmission), model);
+        var model = new GrantRegistrationSubmissionViewModel()
+        {
+            OrganisationId = organisationId.Value
+        }; 
+
+        ViewBag.BackToAllSubmissionsUrl = Url.Action("RegistrationSubmissions");
+
+        return View(nameof(GrantRegistrationSubmission), model);
     }
 
+    [HttpGet] 
+    [Route(PagePath.QueryRegistrationSubmission + "/{organisationId:guid}")]
+    public async Task<IActionResult> QueryRegistrationSubmission(Guid? organisationId)
+    {
+        _currentSession = await _sessionManager.GetSessionAsync(HttpContext.Session);
+
+        if (!GetOrRejectProvidedOrganisationId(organisationId, out RegistrationSubmissionDetailsViewModel existingModel))
+        {
+            return RedirectToAction(PagePath.PageNotFound, "RegistrationSubmissions");
+        }
+
+        SetBackLink(Url.RouteUrl("SubmissionDetails", new { organisationId }), false);
+
+        var model = new QueryRegistrationSubmissionViewModel
+        {
+            OrganisationId = organisationId.Value
+        };
+
+        ViewBag.BackToAllSubmissionsUrl = Url.Action("RegistrationSubmissions");
+
+        return View(nameof(QueryRegistrationSubmission), model);
+    } 
+
     [HttpPost]
-    [Route(PagePath.QueryRegistrationSubmission)]
+    [Route(PagePath.QueryRegistrationSubmission + "/{organisationId:guid}")]
     public async Task<IActionResult> QueryRegistrationSubmission(QueryRegistrationSubmissionViewModel model)
     {
         _currentSession = await _sessionManager.GetSessionAsync(HttpContext.Session);
 
+        if (!GetOrRejectProvidedOrganisationId(model.OrganisationId, out RegistrationSubmissionDetailsViewModel existingModel))
+        {
+            return RedirectToAction(PagePath.PageNotFound, "RegistrationSubmissions");
+        }
         if (!ModelState.IsValid)
         {
-            SetBackLink($"{PagePath.RegistrationSubmissionDetails}/{Guid.NewGuid()}");
+            SetBackLink(Url.RouteUrl("SubmissionDetails", new { model.OrganisationId }), false);
             return View(nameof(QueryRegistrationSubmission), model);
         }
 
-        return Redirect(PagePath.RegistrationSubmissionsRoute);
+        return RedirectToAction(PagePath.RegistrationSubmissionsAction);
     }
 
-    [HttpGet]
-    [Route(PagePath.RejectRegistrationSubmission)]
-    public async Task<IActionResult> RejectRegistrationSubmission()
+    [HttpGet] 
+    [Route(PagePath.RejectRegistrationSubmission + "/{organisationId:guid}", Name = "RejectRegistrationSubmission")]
+    public async Task<IActionResult> RejectRegistrationSubmission(Guid? organisationId)
     {
         _currentSession = await _sessionManager.GetSessionAsync(HttpContext.Session);
 
-        SetBackLink($"{PagePath.RegistrationSubmissionDetails}/{Guid.NewGuid()}");
+        if (!GetOrRejectProvidedOrganisationId(organisationId, out RegistrationSubmissionDetailsViewModel existingModel))
+        {
+            return RedirectToAction(PagePath.PageNotFound, "RegistrationSubmissions");
+        }
+        SetBackLink($"{PagePath.RegistrationSubmissionDetails}/{organisationId}");
+         
+        var model = new RejectRegistrationSubmissionViewModel
+        {
+            OrganisationId = organisationId.Value
+        };
 
-        var model = new RejectRegistrationSubmissionViewModel();
+        ViewBag.BackToAllSubmissionsUrl = Url.Action("RegistrationSubmissions");
 
         return View(nameof(RejectRegistrationSubmission), model);
     }
@@ -205,13 +252,71 @@ public partial class RegistrationSubmissionsController(
     {
         _currentSession = await _sessionManager.GetSessionAsync(HttpContext.Session);
 
+        if (!GetOrRejectProvidedOrganisationId(model.OrganisationId, out RegistrationSubmissionDetailsViewModel existingModel))
+        {
+            return RedirectToAction(PagePath.PageNotFound, "RegistrationSubmissions");
+        }
         if (!ModelState.IsValid)
         {
-            SetBackLink($"{PagePath.RegistrationSubmissionDetails}/{Guid.NewGuid()}");
+            SetBackLink(Url.RouteUrl("SubmissionDetails", new { model.OrganisationId }), false);
             return View(nameof(RejectRegistrationSubmission), model);
         }
 
         return Redirect(PagePath.RegistrationSubmissionsRoute);
+    }
+
+    [HttpGet]
+    [Route(PagePath.ConfirmOfflinePaymentSubmission + "/{organisationId:guid}", Name = "ConfirmOfflinePaymentSubmission")]
+    public async Task<IActionResult> ConfirmOfflinePaymentSubmission(Guid? organisationId)
+    {
+        _currentSession = await _sessionManager.GetSessionAsync(HttpContext.Session);
+
+        if (!GetOrRejectProvidedOrganisationId(organisationId, out var existingModel))
+        {
+            return RedirectToAction(PagePath.PageNotFound, "RegistrationSubmissions");
+        }
+
+        if (string.IsNullOrEmpty(existingModel.PaymentDetails.OfflinePayment))
+        {
+            return RedirectToAction(PagePath.PageNotFound, "RegistrationSubmissions");
+        }
+
+        SetBackLink(Url.RouteUrl("SubmissionDetails", new { organisationId }), false);
+
+        var model = new ConfirmOfflinePaymentSubmissionViewModel
+        {
+            OrganisationId = organisationId,
+            OfflinePaymentAmount = existingModel.PaymentDetails.OfflinePayment
+        };
+
+        return View(nameof(ConfirmOfflinePaymentSubmission), model);
+    }
+
+    [HttpPost]
+    [Route(PagePath.ConfirmOfflinePaymentSubmission + "/{organisationId:guid}", Name = "ConfirmOfflinePaymentSubmission")]
+    public async Task<IActionResult> ConfirmOfflinePaymentSubmission(ConfirmOfflinePaymentSubmissionViewModel model)
+    {
+        _currentSession = await _sessionManager.GetSessionAsync(HttpContext.Session);
+
+        if (!GetOrRejectProvidedOrganisationId(model.OrganisationId, out var existingModel))
+        {
+            return RedirectToAction(PagePath.PageNotFound, "RegistrationSubmissions");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            SetBackLink(Url.RouteUrl("SubmissionDetails", new { model.OrganisationId }), false);
+            return View(nameof(ConfirmOfflinePaymentSubmission), model);
+        }
+
+        if (string.IsNullOrEmpty(model.OfflinePaymentAmount))
+        {
+            return RedirectToAction(PagePath.PageNotFound, "RegistrationSubmissions");
+        }
+
+        // This is where we will call the facade to submit the offline payment.
+
+        return Redirect(Url.RouteUrl("SubmissionDetails", new { model.OrganisationId }));
     }
 
     [HttpGet]

--- a/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController_part.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController_part.cs
@@ -5,6 +5,7 @@ namespace EPR.RegulatorService.Frontend.Web.Controllers.RegistrationSubmissions
     using EPR.RegulatorService.Frontend.Core.Sessions;
     using EPR.RegulatorService.Frontend.Web.Constants;
     using EPR.RegulatorService.Frontend.Web.ViewModels.RegistrationSubmissions;
+
     using Microsoft.AspNetCore.Mvc;
 
     public partial class RegistrationSubmissionsController
@@ -44,7 +45,7 @@ namespace EPR.RegulatorService.Frontend.Web.Controllers.RegistrationSubmissions
             }
 
             var sessionModelWhichMustMatchSession = _currentSession.RegulatorRegistrationSubmissionSession.SelectedRegistration;
-            if ( sessionModelWhichMustMatchSession?.OrganisationID != organisationId.Value)
+            if (sessionModelWhichMustMatchSession?.OrganisationID != organisationId.Value)
             {
                 return false;
             }
@@ -132,17 +133,19 @@ namespace EPR.RegulatorService.Frontend.Web.Controllers.RegistrationSubmissions
         {
             string pathBase = _pathBase.TrimStart('/').TrimEnd('/');
             ViewBag.CustomBackLinkToDisplay = $"/{pathBase}/{PagePath.Home}";
-        }
-        private string GetCustomBackLink(string path)
-        {
-            string pathBase = _pathBase.TrimStart('/').TrimEnd('/');
-            return $"/{pathBase}/{path}";
-        }
+        } 
 
-        private void SetBackLink(string path)
+        private void SetBackLink(string path, bool hasPathBase = true)
         {
-            string pathBase = _pathBase.TrimStart('/').TrimEnd('/');
-            ViewBag.BackLinkToDisplay = $"/{pathBase}/{path}";
+            if (hasPathBase)
+            {
+                string pathBase = _pathBase.TrimStart('/').TrimEnd('/');
+                ViewBag.BackLinkToDisplay = $"/{pathBase}/{path}";
+            }
+            else
+            {
+                ViewBag.BackLinkToDisplay = path;
+            }
         }
     }
 }

--- a/src/EPR.RegulatorService.Frontend.Web/EPR.RegulatorService.Frontend.Web.csproj
+++ b/src/EPR.RegulatorService.Frontend.Web/EPR.RegulatorService.Frontend.Web.csproj
@@ -57,6 +57,12 @@
     <EmbeddedResource Update="Resources\Views\Applications\EnrolmentRequests.cy.resx" />
     <EmbeddedResource Update="Resources\Views\Applications\EnrolmentDecision.en.resx" />
     <EmbeddedResource Update="Resources\Views\Applications\EnrolmentDecision.cy.resx" />
+    <EmbeddedResource Update="Resources\Views\RegistrationSubmissions\ConfirmOfflinePaymentSubmission.cy.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\Views\RegistrationSubmissions\ConfirmOfflinePaymentSubmission.en.resx">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Update="Resources\Views\RegistrationSubmissions\RegistrationSubmissionDetails.cy.resx">
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/src/EPR.RegulatorService.Frontend.Web/Resources/Views/RegistrationSubmissions/ConfirmOfflinePaymentSubmission.cy.resx
+++ b/src/EPR.RegulatorService.Frontend.Web/Resources/Views/RegistrationSubmissions/ConfirmOfflinePaymentSubmission.cy.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="RegistrationSubmissionDetails.RegulatorTitle" xml:space="preserve">
-    <value>Regulator comment</value>
+  <data name="ConfirmOfflinePaymentSubmission.ErrorMessage" xml:space="preserve">
+    <value>[Welsh]Select yes if you want to confirm this payment</value>
   </data>
-  <data name="RegistrationSubmissionDetails.ProducerTitle" xml:space="preserve">
-    <value>Producer comment</value>
+  <data name="ConfirmOfflinePaymentSubmission.PageHeading" xml:space="preserve">
+    <value>[Welsh]Are you sure you want to add this payment?</value>
   </data>
-  <data name="RegistrationSubmissionDetails.NoComments" xml:space="preserve">
-    <value>No comments</value>
+  <data name="ConfirmOfflinePaymentSubmission.PageTitle" xml:space="preserve">
+    <value>[Welsh]Confirm offline payment submission</value>
   </data>
 </root>

--- a/src/EPR.RegulatorService.Frontend.Web/Resources/Views/RegistrationSubmissions/ConfirmOfflinePaymentSubmission.en.resx
+++ b/src/EPR.RegulatorService.Frontend.Web/Resources/Views/RegistrationSubmissions/ConfirmOfflinePaymentSubmission.en.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="RegistrationSubmissionDetails.RegulatorTitle" xml:space="preserve">
-    <value>Regulator comment</value>
+  <data name="ConfirmOfflinePaymentSubmission.ErrorMessage" xml:space="preserve">
+    <value>Select yes if you want to confirm this payment</value>
   </data>
-  <data name="RegistrationSubmissionDetails.ProducerTitle" xml:space="preserve">
-    <value>Producer comment</value>
+  <data name="ConfirmOfflinePaymentSubmission.PageHeading" xml:space="preserve">
+    <value>Are you sure you want to add this payment?</value>
   </data>
-  <data name="RegistrationSubmissionDetails.NoComments" xml:space="preserve">
-    <value>No comments</value>
+  <data name="ConfirmOfflinePaymentSubmission.PageTitle" xml:space="preserve">
+    <value>Confirm offline payment submission</value>
   </data>
 </root>

--- a/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/RegistrationSubmissionComments/Default.cy.resx
+++ b/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/RegistrationSubmissionComments/Default.cy.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="RegistrationSubmissionDetails.RegulatorTitle" xml:space="preserve">
-    <value>[Welsh]Regulator Comment</value>
+    <value>[Welsh]Regulator comment</value>
   </data>
   <data name="RegistrationSubmissionDetails.ProducerTitle" xml:space="preserve">
-    <value>[Welsh]Producer Comment</value>
+    <value>[Welsh]Producer comment</value>
   </data>
 </root>

--- a/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/RegistrationSubmissionList/Default.cy.resx
+++ b/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/RegistrationSubmissionList/Default.cy.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Table.Header.Year" xml:space="preserve">
-    <value>[Welsh]Submission year</value>
+    <value>[Welsh]Relevant year</value>
   </data>
   <data name="Table.Header.Status" xml:space="preserve">
     <value>[Welsh]Submission status</value>

--- a/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/RegistrationSubmissionList/Default.en.resx
+++ b/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/RegistrationSubmissionList/Default.en.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Table.Header.Year" xml:space="preserve">
-    <value>Submission year</value>
+    <value>Relevant year</value>
   </data>
   <data name="Table.Header.Status" xml:space="preserve">
     <value>Submission status</value>

--- a/src/EPR.RegulatorService.Frontend.Web/ViewModels/RegistrationSubmissions/ConfirmOfflinePaymentSubmissionViewModel.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewModels/RegistrationSubmissions/ConfirmOfflinePaymentSubmissionViewModel.cs
@@ -1,0 +1,14 @@
+namespace EPR.RegulatorService.Frontend.Web.ViewModels.RegistrationSubmissions
+{
+    using System.ComponentModel.DataAnnotations;
+
+    public class ConfirmOfflinePaymentSubmissionViewModel
+    {
+        public Guid? OrganisationId { get; set; }
+
+        [Required(ErrorMessage = "ConfirmOfflinePaymentSubmission.ErrorMessage")]
+        public bool? IsOfflinePaymentConfirmed { get; set; }
+
+        public string? OfflinePaymentAmount { get; set; }
+    }
+}

--- a/src/EPR.RegulatorService.Frontend.Web/ViewModels/RegistrationSubmissions/GrantRegistrationSubmissionViewModel.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewModels/RegistrationSubmissions/GrantRegistrationSubmissionViewModel.cs
@@ -1,0 +1,10 @@
+namespace EPR.RegulatorService.Frontend.Web.ViewModels.RegistrationSubmissions
+{
+    using EPR.RegulatorService.Frontend.Web.Attributes;
+    using EPR.RegulatorService.Frontend.Web.Constants;
+
+    public class GrantRegistrationSubmissionViewModel
+    {
+        public Guid OrganisationId { get; set; } 
+    }
+}

--- a/src/EPR.RegulatorService.Frontend.Web/ViewModels/RegistrationSubmissions/PaymentDetailsViewModel.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewModels/RegistrationSubmissions/PaymentDetailsViewModel.cs
@@ -32,7 +32,8 @@ namespace EPR.RegulatorService.Frontend.Web.ViewModels.RegistrationSubmissions
                             )]
         public string? OfflinePayment { get; set; }
 
-        public void EnsureTwoDecimalPlaces() {
+        public void EnsureTwoDecimalPlaces()
+        {
             if (decimal.TryParse(OfflinePayment, NumberStyles.Currency, CultureInfo.InvariantCulture, out decimal parsedValue))
             {
                 // Format the parsed value as a currency with two decimal places
@@ -40,21 +41,30 @@ namespace EPR.RegulatorService.Frontend.Web.ViewModels.RegistrationSubmissions
             }
         }
 
-        public static implicit operator RegistrationSubmissionsOrganisationPaymentDetails(PaymentDetailsViewModel details) => details is null ? null : new RegistrationSubmissionsOrganisationPaymentDetails
+        public static implicit operator RegistrationSubmissionsOrganisationPaymentDetails(PaymentDetailsViewModel details)
         {
-            ApplicationProcessingFee = details.ApplicationProcessingFee,
-            OnlineMarketplaceFee = details.OnlineMarketplaceFee,
-            PreviousPaymentsReceived = details.PreviousPaymentsReceived,
-            SubsidiaryFee = details.SubsidiaryFee
-        };
+            if (details == null)
+            {
+                return null;
+            }
+
+            return new RegistrationSubmissionsOrganisationPaymentDetails
+            {
+                ApplicationProcessingFee = details.ApplicationProcessingFee,
+                OnlineMarketplaceFee = details.OnlineMarketplaceFee,
+                PreviousPaymentsReceived = details.PreviousPaymentsReceived,
+                SubsidiaryFee = details.SubsidiaryFee,
+                OfflinePaymentAmount = string.IsNullOrEmpty(details.OfflinePayment) ? null : decimal.Parse(details.OfflinePayment, CultureInfo.CurrentCulture)
+            };
+        }
 
         public static implicit operator PaymentDetailsViewModel(RegistrationSubmissionsOrganisationPaymentDetails details) => details is null ? null : new()
         {
             ApplicationProcessingFee = details.ApplicationProcessingFee,
             OnlineMarketplaceFee = details.OnlineMarketplaceFee,
             PreviousPaymentsReceived = details.PreviousPaymentsReceived,
-            SubsidiaryFee = details.SubsidiaryFee
+            SubsidiaryFee = details.SubsidiaryFee,
+            OfflinePayment = string.Format(CultureInfo.CurrentCulture, "{0:F2}", details.OfflinePaymentAmount)
         };
-
     }
 }

--- a/src/EPR.RegulatorService.Frontend.Web/ViewModels/RegistrationSubmissions/QueryRegistrationSubmissionViewModel.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewModels/RegistrationSubmissions/QueryRegistrationSubmissionViewModel.cs
@@ -1,13 +1,13 @@
 namespace EPR.RegulatorService.Frontend.Web.ViewModels.RegistrationSubmissions
 {
-    using EPR.RegulatorService.Frontend.Web.Attributes;
-    using EPR.RegulatorService.Frontend.Web.Constants;
+    using EPR.RegulatorService.Frontend.Web.Attributes; 
 
     public class QueryRegistrationSubmissionViewModel
     {
+        public Guid OrganisationId { get; set; }
+
         [CharacterCount("Error.Query", "Error.QueryTooLong", 400)]
         public string? Query { get; set; }
 
-        public string BackToAllSubmissionsUrl { get; set; } = PagePath.RegistrationSubmissionsRoute;
     }
 }

--- a/src/EPR.RegulatorService.Frontend.Web/ViewModels/RegistrationSubmissions/RejectRegistrationSubmissionViewModel.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewModels/RegistrationSubmissions/RejectRegistrationSubmissionViewModel.cs
@@ -5,9 +5,9 @@ namespace EPR.RegulatorService.Frontend.Web.ViewModels.RegistrationSubmissions
 
     public class RejectRegistrationSubmissionViewModel
     {
-        [CharacterCount("Error.Reject", "Error.RejectReasonTooLong", 400)]
-        public string? RejectReason { get; set; }
+        public Guid OrganisationId { get; set; }
 
-        public string BackToAllSubmissionsUrl { get; set; } = PagePath.RegistrationSubmissionsRoute;
+        [CharacterCount("Error.Reject", "Error.RejectReasonTooLong", 400)]
+        public string? RejectReason { get; set; } 
     }
 }

--- a/src/EPR.RegulatorService.Frontend.Web/Views/RegistrationSubmissions/ConfirmOfflinePaymentSubmission.cshtml
+++ b/src/EPR.RegulatorService.Frontend.Web/Views/RegistrationSubmissions/ConfirmOfflinePaymentSubmission.cshtml
@@ -1,0 +1,80 @@
+@using EPR.RegulatorService.Frontend.Web.Extensions
+@using EPR.RegulatorService.Frontend.Web.ViewModels.RegistrationSubmissions
+@using EPR.RegulatorService.Frontend.Web.ViewModels.Shared.GovUK
+
+@model ConfirmOfflinePaymentSubmissionViewModel
+@{
+    ViewData["Title"] = Localizer["ConfirmOfflinePaymentSubmission.PageTitle"];
+    var errorsViewModel = new ErrorsViewModel(ViewData.ModelState.ToErrorDictionary(), Localizer);
+}
+
+@using (Html.BeginRouteForm("ConfirmOfflinePaymentSubmission", new { organisationid = Model.OrganisationId }, FormMethod.Post))
+{
+  @Html.Hidden("OfflinePaymentAmount", Model.OfflinePaymentAmount)
+    <div class="govuk-width-container">
+        <main class="govuk-main-wrapper" id="main-content" role="main">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    @if (!ViewData.ModelState.IsValid)
+                    {
+                        @await Html.PartialAsync("Partials/Govuk/_ErrorSummary", errorsViewModel)
+                    }
+                    <div class="govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+                            <legend class="govuk-visually-hidden">
+                                @Localizer["ConfirmOfflinePaymentSubmission.PageHeading"]
+                            </legend>
+                            <div class="@(ViewData.ModelState.IsValid ? "" : "govuk-form-group--error")">
+                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                                    <h1 id="page-heading" class="govuk-fieldset__heading">
+                                        @Localizer["ConfirmOfflinePaymentSubmission.PageHeading"]
+                                    </h1>
+                                </legend>
+                                <div class="govuk-radios" data-module="govuk-radios">
+                                    @await Html.PartialAsync("Partials/Govuk/_FormItemError", errorsViewModel[nameof(ConfirmOfflinePaymentSubmissionViewModel.IsOfflinePaymentConfirmed)])
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input"
+                                               type="radio"
+                                               aria-labelledby="radio-label-accepted-true"
+                                               gov-for="IsOfflinePaymentConfirmed"
+                                               gov-first-option="true"
+                                               gov-value=true>
+                                        <label id="radio-label-accepted-true"
+                                               class="govuk-label govuk-radios__label"
+                                               gov-for="IsOfflinePaymentConfirmed"
+                                               gov-first-option="true"
+                                               gov-value=true>
+                                            @SharedLocalizer["Yes"]
+                                        </label>
+                                    </div>
+                                    <div class="govuk-radios__item">
+                                        <input class="govuk-radios__input"
+                                               type="radio"
+                                               aria-labelledby="radio-label-accepted-false"
+                                               gov-for="IsOfflinePaymentConfirmed"
+                                               gov-first-option="false"
+                                               gov-value=false>
+                                        <label id="radio-label-accepted-false"
+                                               class="govuk-label govuk-radios__label"
+                                               gov-for="IsOfflinePaymentConfirmed"
+                                               gov-first-option="false"
+                                               gov-value=false>
+                                            @SharedLocalizer["No"]
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+            </div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <button id="continue-button" class="govuk-button" type="submit" data-module="govuk-button">
+                        @SharedLocalizer["Continue"]
+                    </button>
+                </div>
+            </div>
+        </main>
+    </div>
+}

--- a/src/EPR.RegulatorService.Frontend.Web/Views/RegistrationSubmissions/GrantRegistrationSubmission.cshtml
+++ b/src/EPR.RegulatorService.Frontend.Web/Views/RegistrationSubmissions/GrantRegistrationSubmission.cshtml
@@ -1,0 +1,10 @@
+@*
+    For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+*@
+@{
+}
+<h2>To be built under ticket #451998</h2>
+
+<a href="@ViewBag.BackToAllSubmissionsUrl" class="govuk-link govuk-link--no-visited-state">
+    @Localizer["RejectRegistrationSubmission.BackToAllSubmissions"]
+</a>

--- a/src/EPR.RegulatorService.Frontend.Web/Views/RegistrationSubmissions/QueryRegistrationSubmission.cshtml
+++ b/src/EPR.RegulatorService.Frontend.Web/Views/RegistrationSubmissions/QueryRegistrationSubmission.cshtml
@@ -62,8 +62,8 @@
                     </button>
                 </div>
                 <div class="govuk-grid-column-full">
-                    <a href="@Model.BackToAllSubmissionsUrl" class="govuk-link govuk-link--no-visited-state">
-                        @Localizer["QueryRegistrationSubmission.BackToAllSubmissions"]
+                    <a href="@ViewBag.BackToAllSubmissionsUrl" class="govuk-link govuk-link--no-visited-state">
+                        @Localizer["RejectRegistrationSubmission.BackToAllSubmissions"]
                     </a>
                 </div>
             </div>

--- a/src/EPR.RegulatorService.Frontend.Web/Views/RegistrationSubmissions/RejectRegistrationSubmission.cshtml
+++ b/src/EPR.RegulatorService.Frontend.Web/Views/RegistrationSubmissions/RejectRegistrationSubmission.cshtml
@@ -60,7 +60,7 @@
                     </button>
                 </div>
                 <div class="govuk-grid-column-full">
-                    <a href="@Model.BackToAllSubmissionsUrl" class="govuk-link govuk-link--no-visited-state">
+                    <a href="@ViewBag.BackToAllSubmissionsUrl" class="govuk-link govuk-link--no-visited-state">
                         @Localizer["RejectRegistrationSubmission.BackToAllSubmissions"]
                     </a>
                 </div>

--- a/src/EPR.RegulatorService.Frontend.Web/Views/Shared/Partials/_RegistrationSubmissionActionButtons.cshtml
+++ b/src/EPR.RegulatorService.Frontend.Web/Views/Shared/Partials/_RegistrationSubmissionActionButtons.cshtml
@@ -1,3 +1,4 @@
+@using EPR.RegulatorService.Frontend.Web.Constants
 @using EPR.RegulatorService.Frontend.Web.ViewModels.RegistrationSubmissions
 @using EPR.RegulatorService.Frontend.Core.Enums
 @model RegistrationSubmissionDetailsViewModel
@@ -9,19 +10,37 @@
     {
         <ul class="govuk-list govuk-list__horizontal govuk-list__last-spaced">
             <li>
-                <a class="govuk-button" href="">
+                <a class="govuk-button " href="@Url.Action(
+                "GrantRegistrationSubmission",
+                "RegistrationSubmissions",
+                new
+                {
+                  organisationId = Model.OrganisationId
+                })">
                     @Localizer["RegistrationSubmissionDetails.GrantRegistration"]
-                </a>
+                </a> 
             </li>
             <li>
-                <a class="govuk-button govuk-button--inverse " href="">
+                <a class="govuk-button govuk-button--inverse" href="@Url.Action(
+                "QueryRegistrationSubmission",
+                "RegistrationSubmissions",
+                new
+                {
+                  organisationId = Model.OrganisationId
+                })">
                     @Localizer["RegistrationSubmissionDetails.QueryRegistration"]
                 </a>
             </li>
             <li>
-                <a class="govuk-button govuk-button--warning" href="">
+                <a class="govuk-button govuk-button--warning" href="@Url.Action(
+                "RejectRegistrationSubmission",
+                "RegistrationSubmissions",
+                new
+                {
+                  organisationId = Model.OrganisationId
+                })">
                     @Localizer["RegistrationSubmissionDetails.RefuseRegistration"]
-                </a>
+                </a> 
             </li>
         </ul>
     }


### PR DESCRIPTION
Minor code changes in resource files to replace 'Submission year'  with 'Relevant year' for the components:RegistrationSubmissionList.Default.cshtml and _RegistrationSubmissionsFilters.cshtml