### PR TITLE
Feature/459928 change submission year to relevant year

### DIFF
--- a/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/RegistrationSubmissionList/Default.cy.resx
+++ b/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/RegistrationSubmissionList/Default.cy.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Table.Header.Year" xml:space="preserve">
-    <value>[Welsh]Submission year</value>
+    <value>[Welsh]Relevant year</value>
   </data>
   <data name="Table.Header.Status" xml:space="preserve">
     <value>[Welsh]Submission status</value>

--- a/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/RegistrationSubmissionList/Default.en.resx
+++ b/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/RegistrationSubmissionList/Default.en.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Table.Header.Year" xml:space="preserve">
-    <value>Submission year</value>
+    <value>Relevant year</value>
   </data>
   <data name="Table.Header.Status" xml:space="preserve">
     <value>Submission status</value>


### PR DESCRIPTION
459928- Minor code changes in resource files for resource files to replace 'Submission year'  with 'Relevant year' for the components:RegistrationSubmissionList.Default.cshtml and _RegistrationSubmissionsFilters.cshtml