### PR TITLE
Bug/500241 link go back to submission details download page not worki…

### DIFF
--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/Controllers/RegistrationSubmissionsControllerTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/Controllers/RegistrationSubmissionsControllerTests.cs
@@ -3955,10 +3955,10 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
         #region SubmissionDetailsFileDownload
 
         [TestMethod]
-        public void SubmissionDetailsFileDownload_ShouldReturnViewResult()
+        public async void SubmissionDetailsFileDownload_ShouldReturnViewResult()
         {
             // Act
-            var result = _controller.SubmissionDetailsFileDownload();
+            var result = await _controller.SubmissionDetailsFileDownload();
 
             // Assert
             Assert.IsInstanceOfType(result, typeof(ViewResult), "The result should be a ViewResult.");

--- a/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController.cs
@@ -732,7 +732,13 @@ public partial class RegistrationSubmissionsController(
 
     [HttpGet]
     [Route(PagePath.RegistrationSubmissionDetailsFileDownload)]
-    public IActionResult SubmissionDetailsFileDownload() => View("RegistrationSubmissionFileDownload");
+    public async Task<IActionResult> SubmissionDetailsFileDownload()
+    {
+        _currentSession = await _sessionManager.GetSessionAsync(HttpContext.Session);
+        SetBackLink(Url.RouteUrl("SubmissionDetails", new { _currentSession.RegulatorRegistrationSubmissionSession.SelectedRegistration.SubmissionId }), false);
+
+        return View("RegistrationSubmissionFileDownload");
+    }
 
     [HttpGet]
     [Route(PagePath.RegistrationSubmissionFileDownloadFailed)]

--- a/src/EPR.RegulatorService.Frontend.Web/Views/RegistrationSubmissions/RegistrationSubmissionFileDownload.cshtml
+++ b/src/EPR.RegulatorService.Frontend.Web/Views/RegistrationSubmissions/RegistrationSubmissionFileDownload.cshtml
@@ -10,11 +10,9 @@
                       <partial name="Partials/_FileIsDownloadingStatus" />
                       <div class="govuk-grid-row">
                           <div class="govuk-grid-column-full">
-                              @Html.ActionLink(SharedLocalizer["Link.BackToSubmissionDetails"].Value,
-                                       "RegistrationDetails",
-                                       "Registrations",
-                                       null,
-                                       new { @class = "govuk-body govuk-link govuk-link--no-visited-state" })
+                            <a id="back-to-all-submissions" href="@ViewBag.BackLinkToDisplay" class="govuk-link govuk-link--no-visited-state">
+                                @SharedLocalizer["Link.BackToSubmissionDetails"]
+                            </a>
                           </div>
                       </div>
                       @if (!downloadCompleted)


### PR DESCRIPTION
…ng (#193)

* Set Back link in SubmissionDetailsFileDownload Controller Action and Displayed in the corresponding View
* Updated Test to handle Async result