### PR TITLE
Provide FileId for all RegulatorRegistrationDecision events

### DIFF
--- a/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController_part.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController_part.cs
@@ -258,7 +258,8 @@ namespace EPR.RegulatorService.Frontend.Web.Controllers.RegistrationSubmissions
                 IsWelsh = existingModel.NationId == 4,
                 Status = status.ToString(),
                 IsResubmission = existingModel.IsResubmission,
-                FileId = existingModel.IsResubmission ? existingModel.ResubmissionFileId : null
+                FileId = existingModel.IsResubmission ? existingModel.ResubmissionFileId :
+                                                        existingModel.SubmissionDetails.Files.First(x => x.Type == RegistrationSubmissionOrganisationSubmissionSummaryDetails.FileType.company).FileId
             };
 
             if (request.IsResubmission)


### PR DESCRIPTION
Provision the Facade's RegulatorRegistrationDecision API parameter with the FileId for all Submission status conditions