### PR TITLE
Ensure Cancellation event Sets FileId to Null

### DIFF
--- a/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController_part.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController_part.cs
@@ -258,7 +258,11 @@ namespace EPR.RegulatorService.Frontend.Web.Controllers.RegistrationSubmissions
                 IsWelsh = existingModel.NationId == 4,
                 Status = status.ToString(),
                 IsResubmission = existingModel.IsResubmission,
-                FileId = existingModel.IsResubmission ? existingModel.ResubmissionFileId : null
+                FileId = status switch
+                {
+                    RegistrationSubmissionStatus.Cancelled => null,
+                    _ => existingModel.IsResubmission ? existingModel.ResubmissionFileId : null
+                }
             };
 
             if (request.IsResubmission)


### PR DESCRIPTION
Ensured that the FileId is set to Null when a cancellation event is requested - otherwise use the IsResubmission logic as before