### PR TITLE
550052 Ensured cached changes are loaded before going to Facade cache and DB ensuring display of correctly changed data

### DIFF
--- a/src/EPR.RegulatorService.Frontend.Core/Extensions/EnumExtensionMethods.cs
+++ b/src/EPR.RegulatorService.Frontend.Core/Extensions/EnumExtensionMethods.cs
@@ -6,6 +6,10 @@ public static class EnumExtensionMethods
 {
     public static string GetDescription(this Enum genericEnum)
     {
+        if ( genericEnum is null )
+        {
+            return string.Empty;
+        }
         var genericEnumType = genericEnum.GetType();
         var memberInfo = genericEnumType.GetMember(genericEnum.ToString());
         if ((memberInfo.Length > 0))

--- a/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController.cs
@@ -122,8 +122,12 @@ public partial class RegistrationSubmissionsController(
         try
         {
             _currentSession = await _sessionManager.GetSessionAsync(HttpContext.Session);
-            RegistrationSubmissionDetailsViewModel model = await FetchFromSessionOrFacadeAsync(submissionId.Value, _facadeService.GetRegistrationSubmissionDetails);
 
+            if ( !GetOrRejectProvidedSubmissionId(submissionId.Value, out var model))
+            {
+                model = await FetchFromSessionOrFacadeAsync(submissionId.Value, _facadeService.GetRegistrationSubmissionDetails);
+            }
+            
             if (model is null)
             {
                 return RedirectToAction(PagePath.PageNotFound, "RegistrationSubmissions");


### PR DESCRIPTION
1: Ensured when loading details that cached changes are loaded before going to the session submission cache

2: Protected enumeration GetDescription() method from null value