### PR TITLE
Fixed UI issues as part of upgrade to govuk-frontend 5.11.1

### DIFF
--- a/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/PhaseBanner/Default.cy.resx
+++ b/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/PhaseBanner/Default.cy.resx
@@ -19,13 +19,13 @@
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
   <data name="PhaseBanner.Alpha" xml:space="preserve">
-    <value>alffa</value>
+    <value>Alffa</value>
   </data>
   <data name="PhaseBanner.Beta" xml:space="preserve">
-    <value>beta</value>
+    <value>Beta</value>
   </data>
   <data name="PhaseBanner.Live" xml:space="preserve">
-    <value>byw</value>
+    <value>Byw</value>
   </data>
   <data name="PhaseBanner.ThisIsNewService" xml:space="preserve">
     <value>Mae hwn yn wasanaeth newydd – bydd eich </value>

--- a/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/PhaseBanner/Default.en.resx
+++ b/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/PhaseBanner/Default.en.resx
@@ -19,13 +19,13 @@
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
     <data name="PhaseBanner.Alpha" xml:space="preserve">
-        <value>alpha</value>
+        <value>Alpha</value>
     </data>
     <data name="PhaseBanner.Beta" xml:space="preserve">
-        <value>beta</value>
+        <value>Beta</value>
     </data>
     <data name="PhaseBanner.Live" xml:space="preserve">
-        <value>live</value>
+        <value>Live</value>
     </data>
     <data name="PhaseBanner.ThisIsNewService" xml:space="preserve">
         <value>This is a new service – your</value>

--- a/src/EPR.RegulatorService.Frontend.Web/Views/RegistrationSubmissions/Partials/_RegistrationSubmissionsFilters.cshtml
+++ b/src/EPR.RegulatorService.Frontend.Web/Views/RegistrationSubmissions/Partials/_RegistrationSubmissionsFilters.cshtml
@@ -48,16 +48,16 @@
                                 <legend>
                                     <span class="govuk-label govuk-label--m">@Localizer["SubTitle.OrganisationType"].Value</span>
                                 </legend>
-                                <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                                    <div class="epr-filter-panel-checkbox-layout">
-                                        <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
+								<div class="govuk-grid-row govuk-checkboxes" data-module="govuk-checkboxes">
+									<div class="govuk-grid-column-one-third epr-filter-panel-checkbox">
+                                        <div class="govuk-checkboxes__item">
                                             @Html.CheckBoxFor(x => x.IsOrganisationComplianceChecked,
                                                      new { id = "is-organisation-compliance-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-organisation-compliance-checked-label" })
                                             @Html.LabelFor(x => x.IsOrganisationComplianceChecked, Localizer["Checkbox.OrganisationType.Compliance"].Value,
                                                      new { id = "is-organisation-compliance-checked-label", @class = "govuk-label govuk-checkboxes__label epr-filter-panel-checkboxes-label", @for = "is-organisation-compliance-checked-check" })
                                         </div>
                                     </div>
-                                    <div class="epr-filter-panel-checkbox-layout">
+									<div class="govuk-grid-column-one-third">
                                         <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
                                             @Html.CheckBoxFor(x => x.IsOrganisationLargeChecked,
                                                      new { id = "is-organisation-large-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-organisation-large-checked-label" })
@@ -65,7 +65,7 @@
                                                      new { id = "is-organisation-large-checked-label", @class = "govuk-label govuk-checkboxes__label epr-filter-panel-checkboxes-label", @for = "is-organisation-large-checked-check" })
                                         </div>
                                     </div>
-                                    <div class="epr-filter-panel-checkbox-layout">
+									<div class="govuk-grid-column-one-third">
                                         <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
                                             @Html.CheckBoxFor(x => x.IsOrganisationSmallChecked,
                                                      new { id = "is-organisation-small-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-organisation-small-checked-label" })
@@ -82,8 +82,8 @@
                                 <legend>
                                     <span class="govuk-label govuk-label--m">@Localizer["SubTitle.SubmissionStatus"].Value</span>
                                 </legend>
-                                <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                                    <div class="epr-filter-panel-checkbox-layout">
+                                <div class="govuk-grid-row govuk-checkboxes" data-module="govuk-checkboxes">
+									<div class="govuk-grid-column-one-third">
                                         <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
                                             @Html.CheckBoxFor(x => x.IsStatusPendingChecked,
                                                      new { id = "is-status-pending-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-status-pending-checked-label" })
@@ -91,7 +91,7 @@
                                                      new { id = "is-status-pending-checked-label", @class = "govuk-label govuk-checkboxes__label epr-filter-panel-checkboxes-label", @for = "is-status-pending-checked-check" })
                                         </div>
                                     </div>
-                                    <div class="epr-filter-panel-checkbox-layout">
+									<div class="govuk-grid-column-one-third">
                                         <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
                                             @Html.CheckBoxFor(x => x.IsStatusGrantedChecked,
                                                      new { id = "is-status-granted-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-status-granted-checked-label" })
@@ -99,7 +99,7 @@
                                                      new { id = "is-status-granted-checked-label", @class = "govuk-label govuk-checkboxes__label epr-filter-panel-checkboxes-label", @for = "is-status-granted-checked-check" })
                                         </div>
                                     </div>
-                                    <div class="epr-filter-panel-checkbox-layout">
+									<div class="govuk-grid-column-one-third">
                                         <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
                                             @Html.CheckBoxFor(x => x.IsStatusRefusedChecked,
                                                      new { id = "is-status-refused-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-status-refused-checked-label" })
@@ -107,7 +107,7 @@
                                                      new { id = "is-status-refused-checked-label", @class = "govuk-label govuk-checkboxes__label epr-filter-panel-checkboxes-label", @for = "is-status-refused-checked-check" })
                                         </div>
                                     </div>
-                                    <div class="epr-filter-panel-checkbox-layout">
+									<div class="govuk-grid-column-one-third">
                                         <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
                                             @Html.CheckBoxFor(x => x.IsStatusQueriedChecked,
                                                      new { id = "is-status-queried-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-status-queried-checked-label" })
@@ -115,7 +115,7 @@
                                                      new { id = "is-status-queried-checked-label", @class = "govuk-label govuk-checkboxes__label epr-filter-panel-checkboxes-label", @for = "is-status-queried-checked-check" })
                                         </div>
                                     </div>
-                                    <div class="epr-filter-panel-checkbox-layout">
+									<div class="govuk-grid-column-one-third">
                                         <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
                                             @Html.CheckBoxFor(x => x.IsStatusCancelledChecked,
                                                      new { id = "is-status-cancelled-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-status-cancelled-checked-label" })
@@ -131,8 +131,8 @@
                                 <legend>
                                     <span class="govuk-label govuk-label--m">Resubmission status</span>
                                 </legend>
-                                <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                                    <div class="epr-filter-panel-checkbox-layout">
+                                <div class="govuk-grid-row govuk-checkboxes" data-module="govuk-checkboxes">
+									<div class="govuk-grid-column-one-third">
                                         <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
                                             @Html.CheckBoxFor(x => x.IsResubmissionPendingRegistrationChecked,
                                                      new { id = "is-pending-resubmission-type-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-pending-resubmission-type-checked-label" })
@@ -140,7 +140,7 @@
                                                      new { id = "is-pending-resubmission-type-checked-label", @class = "govuk-label govuk-checkboxes__label epr-filter-panel-checkboxes-label", @for = "is-pending-resubmission-type-checked-check" })
                                         </div>
                                     </div>
-                                    <div class="epr-filter-panel-checkbox-layout">
+									<div class="govuk-grid-column-one-third">
                                         <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
                                             @Html.CheckBoxFor(x => x.IsResubmissionAcceptedRegistrationChecked,
                                                      new { id = "is-accepted-resubmission-type-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-accepted-sreubmission-type-checked-label" })
@@ -148,7 +148,7 @@
                                                      new { id = "is-accepted-resubmission-type-checked-label", @class = "govuk-label govuk-checkboxes__label epr-filter-panel-checkboxes-label", @for = "is-accepted-resubmission-type-checked-check" })
                                         </div>
                                     </div>
-                                    <div class="epr-filter-panel-checkbox-layout">
+									<div class="govuk-grid-column-one-third">
                                         <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
                                             @Html.CheckBoxFor(x => x.IsResubmissionRejectedRegistrationChecked,
                                                      new { id = "is-rejected-resubmission-type-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-rejected-resubmission-type-checked-label" })
@@ -164,8 +164,8 @@
                                 <legend>
                                     <span class="govuk-label govuk-label--m">@Localizer["SubTitle.RelevantYear"].Value</span>
                                 </legend>
-                                <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                                    <div class="epr-filter-panel-checkbox-layout">
+                                <div class="govuk-grid-row govuk-checkboxes" data-module="govuk-checkboxes">
+									<div class="govuk-grid-column-one-third">
                                         <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
                                             @Html.CheckBoxFor(x => x.Is2025Checked,
                                                      new { id = "is-year-2025-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-year-2025-checked-label" })
@@ -175,7 +175,7 @@
                                     </div>
                                     @if (Model.Show2026RelevantYearFilter)
                                     {
-                                      <div class="epr-filter-panel-checkbox-layout">
+										<div class="govuk-grid-column-one-third">
                                           <div class="govuk-checkboxes__item epr-filter-panel-checkbox">
                                               @Html.CheckBoxFor(x => x.Is2026Checked,
                                                         new { id = "is-year-2026-checked-check", @class = "govuk-checkboxes__input", labelledby = "is-year-2026-checked-label" })

--- a/src/EPR.RegulatorService.Frontend.Web/Views/Shared/Components/Header/Default.cshtml
+++ b/src/EPR.RegulatorService.Frontend.Web/Views/Shared/Components/Header/Default.cshtml
@@ -32,11 +32,11 @@
     </div>
     <div class="govuk-header__content">
 
-			<a class="govuk-header__link govuk-header__service-name" href="@ViewBag.HeaderViewOverrideUrl">
+      <a class="govuk-header__link govuk-header__service-name" href="@ViewBag.HeaderViewOverrideUrl">
         @SharedLocalizer["Application.Title"]
       </a>
 
-			<nav class="govuk-header__navigation" aria-label="Menu">
+      <nav class="govuk-header__navigation" aria-label="Menu">
         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-expanded="false" hidden="">
           Menu
         </button>

--- a/src/EPR.RegulatorService.Frontend.Web/Views/Shared/Partials/Govuk/_Footer.cshtml
+++ b/src/EPR.RegulatorService.Frontend.Web/Views/Shared/Partials/Govuk/_Footer.cshtml
@@ -50,7 +50,7 @@
         <h2 class="govuk-!-margin-top-3 govuk-footer__heading govuk-heading-m">@Localizer["Footer.GetHelp"]</h2>
         <div class="govuk-footer__section govuk-grid-column-two-thirds">
           <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-7">
-            <li>@Localizer["Footer.Email"]: <a href="mailto: @email">@email</a></li>
+            <li>@Localizer["Footer.Email"]: <a class="govuk-link govuk-link--no-visited-state" href="mailto: @email">@email</a></li>
             <li>@Localizer["Footer.Phone"]: 0300 060 0002</li>
             <li>@Localizer["Footer.CustomerServiceTimes"]</li>
           </ul>

--- a/src/EPR.RegulatorService.Frontend.Web/Views/Shared/Partials/Govuk/_Footer.cshtml
+++ b/src/EPR.RegulatorService.Frontend.Web/Views/Shared/Partials/Govuk/_Footer.cshtml
@@ -138,7 +138,7 @@ else
 
           <h2 class="govuk-!-margin-top-3">@Localizer["Footer.GetHelp"]</h2>
           <ul class="govuk-list govuk-list--spaced govuk-!-margin-bottom-7">
-            <li>@Localizer["Footer.Email"]: <a href="mailto: @email">@email</a></li>
+            <li>@Localizer["Footer.Email"]: <a class="govuk-link govuk-link--no-visited-state" href="mailto: @email">@email</a></li>
             <li>@Localizer["Footer.Phone"]: 0300 060 0002</li>
             <li>@Localizer["Footer.CustomerServiceTimes"]</li>
           </ul>

--- a/src/EPR.RegulatorService.Frontend.Web/assets/scss/application.scss
+++ b/src/EPR.RegulatorService.Frontend.Web/assets/scss/application.scss
@@ -9,6 +9,15 @@ $narrow-media-width: 40.0625em;
 @import './components/language_toggle';
 @import './components/ordered_list';
 
+.govuk-tag{
+    max-width: inherit !important;
+}
+
+.govuk-checkboxes__input:checked + .govuk-checkboxes__label::before,
+.govuk-checkboxes__input + .govuk-checkboxes__label::before {
+  background-color: #fff;
+}
+
 .link-button-destructive {
   font-size: 1.1875rem;
   text-align: left;
@@ -360,11 +369,6 @@ button.epr-filter-panel-control {
 a.epr-filter-panel-control {
   margin: 0 0 20px 15px;
   line-height: 40px;
-}
-
-.epr-filter-panel-checkbox {
-  display: inline-block;
-  background: white;
 }
 
 .epr-filter-panel-checkboxes-label {

--- a/src/EPR.RegulatorService.Frontend.Web/gulpfile.js
+++ b/src/EPR.RegulatorService.Frontend.Web/gulpfile.js
@@ -51,7 +51,7 @@ gulp.task('copy-custom-javascript', () => {
 });
 
 gulp.task('copy-custom-images', () => {
-  return gulp.src('assets/images/*')
+  return gulp.src('assets/images/*', {encoding:false})
     .pipe(gulp.dest('wwwroot/images', { overwrite: true }));
 });
 


### PR DESCRIPTION
- Fixed casing for phase banner status to ensure its sentence case.
- Fixed styling arounf checkboxes on filter pages, the changes to GDS to make checkboxes inline-block, caused conflicts with our own styling so moved to using a proper grid layout and added some additional css.
- Added a govuk-tag override to ensure it does not wrap text onto a new line
- Styling fixes for the footer link