### PR TITLE
Deploy pipeline UI tweak

### DIFF
--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -5,6 +5,17 @@ appendCommitMessageToRunName: false
 name: 'Deploy code to $(serviceName)'
 
 parameters:
+- name: envToDeploy
+  displayName: 'Target Environment to deploy:    (select "development" for dev 1-14)'
+  default: development
+  type: string
+  values:
+    - development
+    - tst
+    - preprod
+    - preprod2
+    - prod
+    - DEV15
 - name: teamName
   displayName: 'Select a dev environment to deploy to:    (works only with "development" as target env)'
   default: 'DEV1'
@@ -24,17 +35,6 @@ parameters:
     - DEV13
     - DEV14
     - DEV16
-- name: envToDeploy
-  displayName: 'Target Environment to deploy:    (select "development" for dev 1-14)'
-  default: development
-  type: string
-  values:
-    - development
-    - tst
-    - preprod
-    - preprod2
-    - prod
-    - DEV15    
 - name: imageTag
   displayName: Enter Tag for the Image (Docker tag) or Release name (Git repo tag)
   default: ''

--- a/pipelines/deployment-pipeline.yaml
+++ b/pipelines/deployment-pipeline.yaml
@@ -36,7 +36,7 @@ parameters:
     - DEV14
     - DEV16
 - name: imageTag
-  displayName: Enter Tag for the Image (Docker tag) or Release name (Git repo tag)
+  displayName: Enter Container Tag to deploy
   default: ''
   type: string
 


### PR DESCRIPTION
1. Re-order deploy params - It's very confusing having the dev env list *before* the "env to deploy" dropdown. Move the dev list to after, so that you select development and then which dev env. I've seen a few people confused by this ordering.
2. Clarify meaning of tag field in deploy. You can't currently deploy git tags, only container tags.

Updated form:

|before|after|
|--|--|
|<img width="395" height="551" alt="shutter_20261-14_11" src="https://github.com/user-attachments/assets/866e5781-a29a-4536-bc5d-9fa8110d6168" /> | <img width="401" height="545" alt="shutter_20261-14_10" src="https://github.com/user-attachments/assets/2d6d01eb-3ff6-4a10-9870-c68ec594eb00" />|

https://eaflood.atlassian.net/browse/SMAL-307



