### PR TITLE
Remove more error hiding

### DIFF
--- a/src/EPR.RegulatorService.Frontend.Core/Services/FacadeService.cs
+++ b/src/EPR.RegulatorService.Frontend.Core/Services/FacadeService.cs
@@ -488,67 +488,38 @@ public class FacadeService : IFacadeService
 
     public async Task SubmitRegistrationFeePaymentAsync(FeePaymentRequest request)
     {
-        try
-        {
-            await PrepareAuthenticatedClient();
+        await PrepareAuthenticatedClient();
 
-            string path = _facadeApiConfig.Endpoints[SubmitRegistrationFeePaymentPath];
-            var response = await _httpClient.PostAsJsonAsync(path, request);
-            response.EnsureSuccessStatusCode();
-        }
-        catch (Exception ex)
-        {
-            _logFacadeServiceError.Invoke(_logger, $"Exception occurred while submitting registration fee payment {nameof(FacadeService)}.{nameof(SubmitRegistrationFeePaymentAsync)}", ex);
-        }
+        string path = _facadeApiConfig.Endpoints[SubmitRegistrationFeePaymentPath];
+        var response = await _httpClient.PostAsJsonAsync(path, request);
+        response.EnsureSuccessStatusCode();
     }
 
     public async Task SubmitPackagingDataResubmissionFeePaymentEventAsync(FeePaymentRequest request)
     {
-        try
-        {
-            await PrepareAuthenticatedClient();
+        await PrepareAuthenticatedClient();
 
-            string path = _facadeApiConfig.Endpoints[PackagingDataResubmissionFeePaymentPath];
-            var response = await _httpClient.PostAsJsonAsync(path, request);
-            response.EnsureSuccessStatusCode();
-        }
-        catch (Exception exception)
-        {
-            _logFacadeServiceError.Invoke(
-                _logger,
-                $"Exception occurred while submitting packaging data resubmission fee payment {nameof(FacadeService)}.{nameof(SubmitPackagingDataResubmissionFeePaymentEventAsync)}",
-                exception);
-        }
+        string path = _facadeApiConfig.Endpoints[PackagingDataResubmissionFeePaymentPath];
+        var response = await _httpClient.PostAsJsonAsync(path, request);
+        response.EnsureSuccessStatusCode();
     }
 
     public async Task<PomPayCalParametersResponse> GetPomPayCalParameters(Guid submissionId, Guid? complianceSchemeId)
     {
-        try
+        await PrepareAuthenticatedClient();
+
+        string url = $"{_facadeApiConfig.Endpoints[GetPomResubmissionPaycalParameters]}/{submissionId}";
+        if (complianceSchemeId.HasValue)
         {
-            await PrepareAuthenticatedClient();
-
-            string url = $"{_facadeApiConfig.Endpoints[GetPomResubmissionPaycalParameters]}/{submissionId}";
-            if (complianceSchemeId.HasValue)
-            {
-                url = $"{url}?ComplianceSchemeId={complianceSchemeId}";
-            }
-
-            var response = await _httpClient.GetAsync(url);
-            response.EnsureSuccessStatusCode();
-
-            string content = await response.Content.ReadAsStringAsync();
-            var payCalDetailsResponse = JsonSerializer.Deserialize<PomPayCalParametersResponse>(content);
-            return payCalDetailsResponse;
+            url = $"{url}?ComplianceSchemeId={complianceSchemeId}";
         }
-        catch (Exception exception)
-        {
-            _logFacadeServiceError.Invoke(
-                _logger,
-                $"Exception occurred while retrieving pom resubmission pay cal parameters {nameof(FacadeService)}.{nameof(GetPomPayCalParameters)}",
-                exception);
 
-            return default;
-        }
+        var response = await _httpClient.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+
+        string content = await response.Content.ReadAsStringAsync();
+        var payCalDetailsResponse = JsonSerializer.Deserialize<PomPayCalParametersResponse>(content);
+        return payCalDetailsResponse;
     }
 
     private async Task<List<T>> GetAllOrganisationSubmissions<T>(

--- a/src/EPR.RegulatorService.Frontend.Core/Services/PaymentFacadeService.cs
+++ b/src/EPR.RegulatorService.Frontend.Core/Services/PaymentFacadeService.cs
@@ -49,18 +49,10 @@ public class PaymentFacadeService : IPaymentFacadeService
 
     public async Task<EndpointResponseStatus> SubmitOfflinePaymentAsync(OfflinePaymentRequest request)
     {
-        try
-        {
-            await SetAuthorisationHeaderAsync();
-            var response = await _httpClient.PostAsJsonAsync(_paymentFacadeApiConfig.Endpoints[SubmitOfflinePaymentPath], request);
-            response.EnsureSuccessStatusCode();
-            return EndpointResponseStatus.Success;
-        }
-        catch (Exception ex)
-        {
-            _logPaymentFacadeServiceError.Invoke(_logger, $"Error occurred while submitting offline payment {nameof(PaymentFacadeService)}.{nameof(SubmitOfflinePaymentAsync)}", ex);
-        }
-        return EndpointResponseStatus.Fail;
+        await SetAuthorisationHeaderAsync();
+        var response = await _httpClient.PostAsJsonAsync(_paymentFacadeApiConfig.Endpoints[SubmitOfflinePaymentPath], request);
+        response.EnsureSuccessStatusCode();
+        return EndpointResponseStatus.Success;
     }
 
     public async Task<ProducerPaymentResponse?> GetProducerPaymentDetailsAsync(ProducerPaymentRequest request)

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Core/Services/FacadeServiceTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Core/Services/FacadeServiceTests.cs
@@ -1470,27 +1470,9 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Services
         }
 
         [TestMethod]
-        [DataRow(HttpStatusCode.OK, EndpointResponseStatus.Success)]
-        [DataRow(HttpStatusCode.BadRequest, EndpointResponseStatus.Fail)]
-        [DataRow(HttpStatusCode.InternalServerError, EndpointResponseStatus.Fail)]
-        [DataRow(HttpStatusCode.ServiceUnavailable, EndpointResponseStatus.Fail)]
-        public async Task SubmitRegistrationFeePaymentAsync_Returns_Correct_Status_BasedOn_Response(HttpStatusCode statusCode, EndpointResponseStatus expectedStatus)
+        public async Task SubmitRegistrationFeePaymentAsync_Succeeds_On_OK_Response()
         {
             // Arrange
-
-            StringContent stringContent = null;
-
-            if (statusCode == HttpStatusCode.BadRequest)
-            {
-                string jsonRequest = JsonSerializer.Serialize(new ValidationProblemDetails { Status = 400 });
-                stringContent = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
-            }
-            else if (statusCode != HttpStatusCode.OK)
-            {
-                string jsonRequest = JsonSerializer.Serialize(new ProblemDetails { Status = 500 });
-                stringContent = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
-            }
-
             var request = _fixture.Create<FeePaymentRequest>();
             _mockHandler
                 .Protected()
@@ -1501,8 +1483,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Services
                 )
                 .ReturnsAsync(() => new HttpResponseMessage
                 {
-                    StatusCode = statusCode,
-                    Content = stringContent
+                    StatusCode = HttpStatusCode.OK
                 })
                 .Verifiable();
 
@@ -1517,34 +1498,15 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Services
                     req.Method == HttpMethod.Post &&
                     req.RequestUri.ToString().Contains("organisation-registration-fee-payment")),
                 ItExpr.IsAny<CancellationToken>());
-
-            stringContent?.Dispose();
         }
 
         [TestMethod]
-        [DataRow(HttpStatusCode.OK, EndpointResponseStatus.Success)]
-        [DataRow(HttpStatusCode.BadRequest, EndpointResponseStatus.Fail)]
-        [DataRow(HttpStatusCode.InternalServerError, EndpointResponseStatus.Fail)]
-        [DataRow(HttpStatusCode.ServiceUnavailable, EndpointResponseStatus.Fail)]
-        public async Task SubmitPackagingDataResubmissionFeePaymentEventAsync_Returns_Correct_Status_BasedOn_Response(
-            HttpStatusCode statusCode,
-            EndpointResponseStatus expectedStatus)
+        [DataRow(HttpStatusCode.BadRequest)]
+        [DataRow(HttpStatusCode.InternalServerError)]
+        [DataRow(HttpStatusCode.ServiceUnavailable)]
+        public async Task SubmitPackagingDataResubmissionFeePaymentEventAsync_Throws_On_Error_Response(HttpStatusCode statusCode)
         {
             // Arrange
-
-            StringContent stringContent = null;
-
-            if (statusCode == HttpStatusCode.BadRequest)
-            {
-                string jsonRequest = JsonSerializer.Serialize(new ValidationProblemDetails { Status = 400 });
-                stringContent = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
-            }
-            else if (statusCode != HttpStatusCode.OK)
-            {
-                string jsonRequest = JsonSerializer.Serialize(new ProblemDetails { Status = 500 });
-                stringContent = new StringContent(jsonRequest, Encoding.UTF8, "application/json");
-            }
-
             var request = _fixture.Create<FeePaymentRequest>();
             _mockHandler
                 .Protected()
@@ -1555,8 +1517,30 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Services
                 )
                 .ReturnsAsync(() => new HttpResponseMessage
                 {
-                    StatusCode = statusCode,
-                    Content = stringContent
+                    StatusCode = statusCode
+                })
+                .Verifiable();
+
+            // Act & Assert
+            await Assert.ThrowsExceptionAsync<HttpRequestException>(async () =>
+                await _facadeService.SubmitPackagingDataResubmissionFeePaymentEventAsync(request));
+        }
+
+        [TestMethod]
+        public async Task SubmitPackagingDataResubmissionFeePaymentEventAsync_Succeeds_On_OK_Response()
+        {
+            // Arrange
+            var request = _fixture.Create<FeePaymentRequest>();
+            _mockHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(() => new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK
                 })
                 .Verifiable();
 
@@ -1571,8 +1555,6 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Services
                     req.Method == HttpMethod.Post &&
                     req.RequestUri.ToString().Contains("organisation-packaging-data-resubmission-fee-payment")),
                 ItExpr.IsAny<CancellationToken>());
-
-            stringContent?.Dispose();
         }
 
         [TestMethod]
@@ -1844,7 +1826,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Services
         }
 
         [TestMethod]
-        public async Task GetPomPayCalParameters_Should_LogError_Return_Default_Response()
+        public async Task GetPomPayCalParameters_Throws_On_Error_Response()
         {
             // Arrange
             var submissionId = Guid.NewGuid();
@@ -1863,18 +1845,9 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Services
                 })
                 .Verifiable();
 
-            // Act
-            var result = await _facadeService.GetPomPayCalParameters(submissionId, csoId);
-
-            // Assert
-            Assert.IsNull(result);
-            _mockHandler.Protected().Verify(
-                "SendAsync",
-                Times.Once(),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    req.Method == HttpMethod.Get &&
-                    req.RequestUri.ToString().Contains("pom/get-resubmission-paycal-parameters")),
-                ItExpr.IsAny<CancellationToken>());
+            // Act & Assert
+            await Assert.ThrowsExceptionAsync<HttpRequestException>(async () =>
+                await _facadeService.GetPomPayCalParameters(submissionId, csoId));
         }
 
         public static class PaginatedListHelper

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Core/Services/PaymentFacadeServiceTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Core/Services/PaymentFacadeServiceTests.cs
@@ -94,7 +94,7 @@ public class PaymentFacadeServiceTests
     }
 
     [TestMethod]
-    public async Task SubmitOfflinePaymentAsync_Logs_And_ReturnsFail_WhenResponseIsUnsuccessful()
+    public async Task SubmitOfflinePaymentAsync_Throws_On_Error_Response()
     {
         // Arrange
         var request = _fixture.Create<OfflinePaymentRequest>();
@@ -111,12 +111,9 @@ public class PaymentFacadeServiceTests
             })
             .Verifiable();
 
-        // Act
-        var result = await _paymentFacadeService.SubmitOfflinePaymentAsync(request);
-
-        // Assert
-        Assert.AreEqual(EndpointResponseStatus.Fail, result);
-        AssertTest(result, "offline-payments");       
+        // Act & Assert
+        await Assert.ThrowsExceptionAsync<HttpRequestException>(async () =>
+            await _paymentFacadeService.SubmitOfflinePaymentAsync(request));
     }
 
     [TestMethod]

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/Controllers/ApplicationsControllerTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/Controllers/ApplicationsControllerTests.cs
@@ -363,7 +363,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
         }
         
         [TestMethod]
-        public async Task? Application_Accepted_But_Email_Failed_To_Send_Stay_On_Same_Page()
+        public async Task? Application_Accepted_But_Email_Failed_Throws()
         {
             // Arrange
             var organisationId = _acceptedUserOrganisationId;
@@ -376,7 +376,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             };
             _sessionManagerMock.Setup(x => x.GetSessionAsync(It.IsAny<ISession>()))
                 .ReturnsAsync(session);
-        
+
             var approvedUser = new User() { Enrolment = new Enrolment() { ServiceRole = ServiceRole.ApprovedPerson } };
             var organisationDetails = new OrganisationEnrolments()
             {
@@ -386,22 +386,19 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             };
             _facadeServiceMock.Setup(x => x.GetOrganisationEnrolments(organisationId))
                 .ReturnsAsync(organisationDetails);
-        
+
+            var exception = new Exception("Failed to send email");
             _facadeServiceMock.Setup(x => x.SendEnrolmentEmails(It.IsAny<EnrolmentDecisionRequest>()))
-                .Throws(new Exception("Failed to send email"));
-        
-            // Act
-            var result = await _systemUnderTest.AcceptApplication(AcceptedUserFirstName, AcceptedUserLastName, AcceptedUserEmail,
-                ServiceRole.ApprovedPerson);
-        
-            // Assert
-            result.Should().BeOfType<ViewResult>();
-            var viewResult = result as ViewResult;
-            viewResult!.ViewName.Should().Be(nameof(ApplicationsController.EnrolmentRequests));
+                .Throws(exception);
+
+            // Act & Assert
+            await Assert.ThrowsExceptionAsync<Exception>(async () =>
+                await _systemUnderTest.AcceptApplication(AcceptedUserFirstName, AcceptedUserLastName, AcceptedUserEmail,
+                    ServiceRole.ApprovedPerson));
         }
         
         [TestMethod]
-        public async Task? Application_Accepted_But_Database_Save_Failed_Stay_On_Same_Page()
+        public async Task? Application_Accepted_But_Database_Save_Failed_Throws()
         {
             // Arrange
             var organisationId = _acceptedUserOrganisationId;
@@ -414,7 +411,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             };
             _sessionManagerMock.Setup(x => x.GetSessionAsync(It.IsAny<ISession>()))
                 .ReturnsAsync(session);
-        
+
             var approvedUser = new User() { Enrolment = new Enrolment() { ServiceRole = ServiceRole.ApprovedPerson } };
             var organisationDetails = new OrganisationEnrolments()
             {
@@ -424,21 +421,18 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Controllers
             };
             _facadeServiceMock.Setup(x => x.GetOrganisationEnrolments(organisationId))
                 .ReturnsAsync(organisationDetails);
-        
+
             _facadeServiceMock.Setup(x => x.SendEnrolmentEmails(It.IsAny<EnrolmentDecisionRequest>()))
                 .ReturnsAsync(EndpointResponseStatus.Success);
-        
+
+            var exception = new Exception("Failed to save to DB");
             _facadeServiceMock.Setup(x => x.UpdateEnrolment(It.IsAny<UpdateEnrolment>()))
-                .Throws(new Exception("Failed to save to DB"));
-        
-            // Act
-            var result = await _systemUnderTest.AcceptApplication(AcceptedUserFirstName, AcceptedUserLastName, AcceptedUserEmail,
-                ServiceRole.ApprovedPerson);
-        
-            // Assert
-            result.Should().BeOfType<ViewResult>();
-            var viewResult = result as ViewResult;
-            viewResult!.ViewName.Should().Be(nameof(ApplicationsController.EnrolmentRequests));
+                .Throws(exception);
+
+            // Act & Assert
+            await Assert.ThrowsExceptionAsync<Exception>(async () =>
+                await _systemUnderTest.AcceptApplication(AcceptedUserFirstName, AcceptedUserLastName, AcceptedUserEmail,
+                    ServiceRole.ApprovedPerson));
         }
         
         [TestMethod]

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/CompliancePaymentDetailsViewComponentTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/CompliancePaymentDetailsViewComponentTests.cs
@@ -106,7 +106,7 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
     }
 
     [TestMethod]
-    public async Task InvokeAsync_Logs_Error_And_Returns_CorrectView_With_DefaultModel_When_Service_Throws()
+    public async Task InvokeAsync_Throws_Exception_When_Service_Throws()
     {
         // Arrange
         var complianceSchemeMembers = new List<CsoMembershipDetailsDto> {
@@ -123,22 +123,10 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
         _paymentFacadeServiceMock.Setup(x => x.GetCompliancePaymentDetailsAsync(It.IsAny<CompliancePaymentRequest>()))
             .ThrowsAsync(exception);
 
-        // Act
-        var result = await _sut.InvokeAsync(_registrationSumissionDetailsViewModel);
+        // Act & Assert
+        await Assert.ThrowsExceptionAsync<Exception>(async () =>
+            await _sut.InvokeAsync(_registrationSumissionDetailsViewModel));
 
-        // Assert
-        Assert.IsNotNull(result);
-        result.Should().BeOfType<ViewViewComponentResult>();
-        var model = result.ViewData.Model as CompliancePaymentResponse;
-        model.Should().BeNull();
-        _paymentFacadeServiceMock.Verify(r => r.GetCompliancePaymentDetailsAsync(It.IsAny<CompliancePaymentRequest>()), Times.AtMostOnce);
-        _loggerMock.Verify(logger =>
-               logger.Log(
-                   LogLevel.Error,
-                   It.IsAny<EventId>(),
-                   It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Unable to retrieve the compliance scheme payment details for {_registrationSumissionDetailsViewModel.SubmissionId}")),
-                    exception,
-                   It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-               Times.Once);
+        _paymentFacadeServiceMock.Verify(r => r.GetCompliancePaymentDetailsAsync(It.IsAny<CompliancePaymentRequest>()), Times.Once);
     }
 }

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/PackagingCompliancePaymentDetailsViewComponentTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/PackagingCompliancePaymentDetailsViewComponentTests.cs
@@ -170,7 +170,7 @@ public class PackagingCompliancePaymentDetailsViewComponentTests : ViewComponent
     }
 
     [TestMethod]
-    public async Task InvokeAsync_Logs_Error_And_Returns_CorrectView_With_DefaultModel_When_Service_Throws()
+    public async Task InvokeAsync_Throws_Exception_When_Service_Throws()
     {
         // Arrange
         var exception = new Exception("error");
@@ -178,23 +178,11 @@ public class PackagingCompliancePaymentDetailsViewComponentTests : ViewComponent
             It.IsAny<PackagingCompliancePaymentRequest>()))
             .ThrowsAsync(exception);
 
-        // Act
-        var result = await _sut.InvokeAsync(_submissionDetailsViewModel);
+        // Act & Assert
+        await Assert.ThrowsExceptionAsync<Exception>(async () =>
+            await _sut.InvokeAsync(_submissionDetailsViewModel));
 
-        // Assert
-        Assert.IsNotNull(result);
-        result.Should().BeOfType<ViewViewComponentResult>();
-        var model = result.ViewData.Model as PackagingCompliancePaymentResponse;
-        model.Should().BeNull();
         _paymentFacadeServiceMock.Verify(r => r.GetCompliancePaymentDetailsForResubmissionAsync(
-            It.IsAny<PackagingCompliancePaymentRequest>()), Times.AtMostOnce);
-        _loggerMock.Verify(logger =>
-               logger.Log(
-                   LogLevel.Error,
-                   It.IsAny<EventId>(),
-                   It.Is<It.IsAnyType>((v, t) => v.ToString().Contains($"Unable to retrieve the packaging compliance scheme payment details for {_submissionDetailsViewModel.SubmissionId}")),
-                    exception,
-                   It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-               Times.Once);
+            It.IsAny<PackagingCompliancePaymentRequest>()), Times.Once);
     }
 }

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/PackagingProducerPaymentDetailsViewComponentTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/PackagingProducerPaymentDetailsViewComponentTests.cs
@@ -164,7 +164,7 @@ public class PackagingProducerPaymentDetailsViewComponentTests : ViewComponentsT
     }
 
     [TestMethod]
-    public async Task InvokeAsync_Logs_Error_And_Returns_CorrectView_With_DefaultModel_When_Service_Throws()
+    public async Task InvokeAsync_Throws_Exception_When_Service_Throws()
     {
         // Arrange
         var exception = new Exception("error");
@@ -172,24 +172,12 @@ public class PackagingProducerPaymentDetailsViewComponentTests : ViewComponentsT
             It.IsAny<PackagingProducerPaymentRequest>()))
             .ThrowsAsync(exception);
 
-        // Act
-        var result = await _sut.InvokeAsync(_submissionDetailsViewModel);
+        // Act & Assert
+        await Assert.ThrowsExceptionAsync<Exception>(async () =>
+            await _sut.InvokeAsync(_submissionDetailsViewModel));
 
-        // Assert
-        Assert.IsNotNull(result);
-        result.Should().BeOfType<ViewViewComponentResult>();
-        var model = result.ViewData.Model as PackagingProducerPaymentResponse;
-        model.Should().BeNull();
         _paymentFacadeServiceMock.Verify(r => r.GetProducerPaymentDetailsForResubmissionAsync(
-            It.IsAny<PackagingProducerPaymentRequest>()), Times.AtMostOnce);
-        _loggerMock.Verify(logger =>
-               logger.Log(
-                   LogLevel.Error,
-                   It.IsAny<EventId>(),
-                   It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Unable to retrieve the packaging producer payment details for")),
-                    exception,
-                   It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-               Times.Once);
+            It.IsAny<PackagingProducerPaymentRequest>()), Times.Once);
     }
 
     [TestMethod]

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/ProducerPaymentDetailsViewComponentTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/ProducerPaymentDetailsViewComponentTests.cs
@@ -108,7 +108,7 @@ public class ProducerPaymentDetailsViewComponentTests : ViewComponentsTestBase
     }
 
     [TestMethod]
-    public async Task InvokeAsync_Logs_Error_And_Returns_CorrectView_With_DefaultModel_When_Service_Throws()
+    public async Task InvokeAsync_Throws_Exception_When_Service_Throws()
     {
         // Arrange
         _registrationSumissionDetailsViewModel.SubmissionDetails = new SubmissionDetailsViewModel
@@ -120,23 +120,11 @@ public class ProducerPaymentDetailsViewComponentTests : ViewComponentsTestBase
             It.IsAny<ProducerPaymentRequest>()))
             .ThrowsAsync(exception);
 
-        // Act
-        var result = await _sut.InvokeAsync(_registrationSumissionDetailsViewModel);
+        // Act & Assert
+        await Assert.ThrowsExceptionAsync<Exception>(async () =>
+            await _sut.InvokeAsync(_registrationSumissionDetailsViewModel));
 
-        // Assert
-        Assert.IsNotNull(result);
-        result.Should().BeOfType<ViewViewComponentResult>();
-        var model = result.ViewData.Model as ProducerPaymentResponse;
-        model.Should().BeNull();
         _paymentFacadeServiceMock.Verify(r => r.GetProducerPaymentDetailsAsync(
-            It.IsAny<ProducerPaymentRequest>()), Times.AtMostOnce);
-        _loggerMock.Verify(logger =>
-               logger.Log(
-                   LogLevel.Error,
-                   It.IsAny<EventId>(),
-                   It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("Unable to retrieve the producer payment details for")),
-                    exception,
-                   It.IsAny<Func<It.IsAnyType, Exception, string>>()),
-               Times.Once);
+            It.IsAny<ProducerPaymentRequest>()), Times.Once);
     }
 }

--- a/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController_part.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Controllers/RegistrationSubmissions/RegistrationSubmissionsController_part.cs
@@ -366,38 +366,21 @@ namespace EPR.RegulatorService.Frontend.Web.Controllers.RegistrationSubmissions
 
         private async Task<IActionResult> SubmitRegulatorRejectDecisionAsync(RegistrationSubmissionDetailsViewModel registrationSubmissionDetailsViewModel)
         {
-            try
-            {
-                var regulatorDecisionRequest = GetDecisionRequest(registrationSubmissionDetailsViewModel, Core.Enums.RegistrationSubmissionStatus.Refused);
+            var regulatorDecisionRequest = GetDecisionRequest(registrationSubmissionDetailsViewModel, Core.Enums.RegistrationSubmissionStatus.Refused);
 
-                regulatorDecisionRequest.Comments = registrationSubmissionDetailsViewModel.RejectReason;
+            regulatorDecisionRequest.Comments = registrationSubmissionDetailsViewModel.RejectReason;
 
-                var status = await _facadeService.SubmitRegulatorRegistrationDecisionAsync(regulatorDecisionRequest);
+            var status = await _facadeService.SubmitRegulatorRegistrationDecisionAsync(regulatorDecisionRequest);
 
-                await UpdateOrganisationDetailsChangeHistoryAsync(registrationSubmissionDetailsViewModel, status, regulatorDecisionRequest);
+            await UpdateOrganisationDetailsChangeHistoryAsync(registrationSubmissionDetailsViewModel, status, regulatorDecisionRequest);
 
-                return status == Core.Models.EndpointResponseStatus.Success
-                    ? RedirectToAction(PagePath.RegistrationSubmissionsAction)
-                    : RedirectToRoute("ServiceNotAvailable",
-                    new
-                    {
-                        backLink = $"{PagePath.RegistrationSubmissionDetails}/{registrationSubmissionDetailsViewModel.SubmissionId}"
-                    });
-            }
-            catch (Exception ex)
-            {
-                _logControllerError.Invoke(
-                    logger,
-                    $"Exception received while refusing submission" +
-                    $"{nameof(RegistrationSubmissionsController)}.{nameof(ConfirmRegistrationRefusal)}", ex);
-
-                return RedirectToRoute(
-                    "ServiceNotAvailable",
-                    new
-                    {
-                        backLink = $"{PagePath.RegistrationSubmissionDetails}/{registrationSubmissionDetailsViewModel.SubmissionId}"
-                    });
-            }
+            return status == Core.Models.EndpointResponseStatus.Success
+                ? RedirectToAction(PagePath.RegistrationSubmissionsAction)
+                : RedirectToRoute("ServiceNotAvailable",
+                new
+                {
+                    backLink = $"{PagePath.RegistrationSubmissionDetails}/{registrationSubmissionDetailsViewModel.SubmissionId}"
+                });
         }
     }
 }

--- a/src/EPR.RegulatorService.Frontend.Web/Extensions/ClaimsExtensions.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Extensions/ClaimsExtensions.cs
@@ -21,7 +21,13 @@ namespace EPR.RegulatorService.Frontend.Web.Extensions
 
         public static UserData? TryGetUserData(this ClaimsPrincipal claimsPrincipal)
         {
-            return claimsPrincipal.GetUserData();
+            var userDataClaim = claimsPrincipal.Claims.FirstOrDefault(c => c.Type == ClaimTypes.UserData);
+            if (userDataClaim == null)
+            {
+                return null;
+            }
+
+            return JsonSerializer.Deserialize<UserData>(userDataClaim.Value);
         }
 
         public static UserData GetInvitedUserData(this ClaimsPrincipal claimsPrincipal)

--- a/src/EPR.RegulatorService.Frontend.Web/Extensions/ClaimsExtensions.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Extensions/ClaimsExtensions.cs
@@ -21,33 +21,19 @@ namespace EPR.RegulatorService.Frontend.Web.Extensions
 
         public static UserData? TryGetUserData(this ClaimsPrincipal claimsPrincipal)
         {
-            try
-            {
-                return claimsPrincipal.GetUserData();
-            }
-            catch (Exception)
-            {
-                return null;
-            }
+            return claimsPrincipal.GetUserData();
         }
 
         public static UserData GetInvitedUserData(this ClaimsPrincipal claimsPrincipal)
         {
-            try
-            {
-                var idClaim = claimsPrincipal.Claims.Single(claim => claim.Type == ClaimConstants.ObjectId);
-                var emailClaim = claimsPrincipal.Claims.Single(claim => claim.Type == ClaimTypes.Email);
+            var idClaim = claimsPrincipal.Claims.Single(claim => claim.Type == ClaimConstants.ObjectId);
+            var emailClaim = claimsPrincipal.Claims.Single(claim => claim.Type == ClaimTypes.Email);
 
-                return new UserData
-                {
-                    Id = Guid.Parse(idClaim.Value),
-                    Email = emailClaim.Value
-                };
-            }
-            catch (Exception)
+            return new UserData
             {
-                return new UserData();
-            }
+                Id = Guid.Parse(idClaim.Value),
+                Email = emailClaim.Value
+            };
         }
 
         public static async Task UpdateUserDataClaimsAndSignInAsync(HttpContext httpContext, UserData userData)

--- a/src/EPR.RegulatorService.Frontend.Web/Properties/launchSettings.json
+++ b/src/EPR.RegulatorService.Frontend.Web/Properties/launchSettings.json
@@ -26,7 +26,8 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "FacadeApi:BaseUrl": "https://localhost:7253/api/",
         "EprAuthorizationConfig:FacadeBaseUrl": "https://localhost:7253/api/",
-        "ReprocessorExporterFacadeApi:BaseUrl": "https://localhost:7253/api/"
+        "ReprocessorExporterFacadeApi:BaseUrl": "https://localhost:7253/api/",
+        "PaymentFacadeApi:BaseUrl": "https://localhost:7107/"
       }
     },
     "IIS Express": {

--- a/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/ProducerPaymentDetailsViewComponent.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/ProducerPaymentDetailsViewComponent.cs
@@ -21,53 +21,43 @@ public class ProducerPaymentDetailsViewComponent(IOptions<PaymentDetailsOptions>
 
     public async Task<ViewViewComponentResult> InvokeAsync(RegistrationSubmissionDetailsViewModel viewModel)
     {
-        try
+        var producerPaymentResponse = await paymentFacadeService.GetProducerPaymentDetailsAsync(new ProducerPaymentRequest
         {
-            var producerPaymentResponse = await paymentFacadeService.GetProducerPaymentDetailsAsync(new ProducerPaymentRequest
-            {
-                ApplicationReferenceNumber = viewModel.ReferenceNumber,
-                NoOfSubsidiariesOnlineMarketplace = viewModel.ProducerDetails.NoOfSubsidiariesOnlineMarketPlace,
-                NumberOfSubsidiaries = viewModel.ProducerDetails.NoOfSubsidiaries,
-                IsLateFeeApplicable = viewModel.ProducerDetails.IsLateFeeApplicable,
-                IsProducerOnlineMarketplace = viewModel.ProducerDetails.IsProducerOnlineMarketplace,
-                ProducerType = viewModel.ProducerDetails.ProducerType,
-                Regulator = viewModel.NationCode,
-                SubmissionDate = TimeZoneInfo.ConvertTimeToUtc(viewModel.IsResubmission
-                ? viewModel.SubmissionDetails.TimeAndDateOfResubmission.Value
-                : viewModel.SubmissionDetails.TimeAndDateOfSubmission)
-            });
+            ApplicationReferenceNumber = viewModel.ReferenceNumber,
+            NoOfSubsidiariesOnlineMarketplace = viewModel.ProducerDetails.NoOfSubsidiariesOnlineMarketPlace,
+            NumberOfSubsidiaries = viewModel.ProducerDetails.NoOfSubsidiaries,
+            IsLateFeeApplicable = viewModel.ProducerDetails.IsLateFeeApplicable,
+            IsProducerOnlineMarketplace = viewModel.ProducerDetails.IsProducerOnlineMarketplace,
+            ProducerType = viewModel.ProducerDetails.ProducerType,
+            Regulator = viewModel.NationCode,
+            SubmissionDate = TimeZoneInfo.ConvertTimeToUtc(viewModel.IsResubmission
+            ? viewModel.SubmissionDetails.TimeAndDateOfResubmission.Value
+            : viewModel.SubmissionDetails.TimeAndDateOfSubmission)
+        });
 
-            if (producerPaymentResponse is null)
-            {
-                return View(default(ProducerPaymentDetailsViewModel));
-            }
-
-            var producerPaymentDetailsViewModel = new ProducerPaymentDetailsViewModel
-            {
-                ApplicationProcessingFee = ConvertToPoundsFromPence(producerPaymentResponse.ApplicationProcessingFee),
-                LateRegistrationFee = ConvertToPoundsFromPence(producerPaymentResponse.LateRegistrationFee),
-                OnlineMarketplaceFee = ConvertToPoundsFromPence(producerPaymentResponse.OnlineMarketplaceFee),
-                PreviousPaymentsReceived = ConvertToPoundsFromPence(producerPaymentResponse.PreviousPaymentsReceived),
-                SubsidiaryFee = ConvertToPoundsFromPence(producerPaymentResponse.SubsidiaryFee - producerPaymentResponse.SubsidiariesFeeBreakdown.SubsidiaryOnlineMarketPlaceFee),
-                SubsidiaryOnlineMarketPlaceFee = ConvertToPoundsFromPence(producerPaymentResponse.SubsidiariesFeeBreakdown.SubsidiaryOnlineMarketPlaceFee),
-                SubTotal = ConvertToPoundsFromPence(producerPaymentResponse.TotalChargeableItems),
-                TotalOutstanding = ConvertToPoundsFromPence(PaymentHelper.GetUpdatedTotalOutstanding(producerPaymentResponse.TotalOutstanding, options.Value.ShowZeroFeeForTotalOutstanding)),
-                ProducerSize = $"{char.ToUpperInvariant(viewModel.ProducerDetails.ProducerType[0])}{viewModel.ProducerDetails.ProducerType[1..]}",
-                NumberOfSubsidiaries = viewModel.ProducerDetails.NoOfSubsidiaries,
-                NumberOfSubsidiariesBeingOnlineMarketplace = producerPaymentResponse.SubsidiariesFeeBreakdown.OnlineMarketPlaceSubsidiariesCount,
-                ResubmissionStatus = viewModel.ResubmissionStatus,
-                Status = viewModel.Status,
-            };
-
-            return View(producerPaymentDetailsViewModel);
-        }
-        catch (Exception ex)
+        if (producerPaymentResponse is null)
         {
-            _logViewComponentError.Invoke(logger,
-               $"Unable to retrieve the producer payment details for {viewModel.SubmissionId} in {nameof(ProducerPaymentDetailsViewComponent)}.{nameof(InvokeAsync)}", ex);
-
             return View(default(ProducerPaymentDetailsViewModel));
         }
+
+        var producerPaymentDetailsViewModel = new ProducerPaymentDetailsViewModel
+        {
+            ApplicationProcessingFee = ConvertToPoundsFromPence(producerPaymentResponse.ApplicationProcessingFee),
+            LateRegistrationFee = ConvertToPoundsFromPence(producerPaymentResponse.LateRegistrationFee),
+            OnlineMarketplaceFee = ConvertToPoundsFromPence(producerPaymentResponse.OnlineMarketplaceFee),
+            PreviousPaymentsReceived = ConvertToPoundsFromPence(producerPaymentResponse.PreviousPaymentsReceived),
+            SubsidiaryFee = ConvertToPoundsFromPence(producerPaymentResponse.SubsidiaryFee - producerPaymentResponse.SubsidiariesFeeBreakdown.SubsidiaryOnlineMarketPlaceFee),
+            SubsidiaryOnlineMarketPlaceFee = ConvertToPoundsFromPence(producerPaymentResponse.SubsidiariesFeeBreakdown.SubsidiaryOnlineMarketPlaceFee),
+            SubTotal = ConvertToPoundsFromPence(producerPaymentResponse.TotalChargeableItems),
+            TotalOutstanding = ConvertToPoundsFromPence(PaymentHelper.GetUpdatedTotalOutstanding(producerPaymentResponse.TotalOutstanding, options.Value.ShowZeroFeeForTotalOutstanding)),
+            ProducerSize = $"{char.ToUpperInvariant(viewModel.ProducerDetails.ProducerType[0])}{viewModel.ProducerDetails.ProducerType[1..]}",
+            NumberOfSubsidiaries = viewModel.ProducerDetails.NoOfSubsidiaries,
+            NumberOfSubsidiariesBeingOnlineMarketplace = producerPaymentResponse.SubsidiariesFeeBreakdown.OnlineMarketPlaceSubsidiariesCount,
+            ResubmissionStatus = viewModel.ResubmissionStatus,
+            Status = viewModel.Status,
+        };
+
+        return View(producerPaymentDetailsViewModel);
     }
     private static decimal ConvertToPoundsFromPence(decimal amount) => amount / 100;
 }

--- a/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/ProducerPaymentDetailsViewComponent.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/ProducerPaymentDetailsViewComponent.cs
@@ -40,19 +40,24 @@ public class ProducerPaymentDetailsViewComponent(IOptions<PaymentDetailsOptions>
             return View(default(ProducerPaymentDetailsViewModel));
         }
 
+        var subsidiariesBreakdown = producerPaymentResponse.SubsidiariesFeeBreakdown;
+        var subsidiaryOmpFee = subsidiariesBreakdown?.SubsidiaryOnlineMarketPlaceFee ?? 0;
+        var producerDetails = viewModel.ProducerDetails;
+        var producerType = producerDetails?.ProducerType ?? "Unknown";
+
         var producerPaymentDetailsViewModel = new ProducerPaymentDetailsViewModel
         {
             ApplicationProcessingFee = ConvertToPoundsFromPence(producerPaymentResponse.ApplicationProcessingFee),
             LateRegistrationFee = ConvertToPoundsFromPence(producerPaymentResponse.LateRegistrationFee),
             OnlineMarketplaceFee = ConvertToPoundsFromPence(producerPaymentResponse.OnlineMarketplaceFee),
             PreviousPaymentsReceived = ConvertToPoundsFromPence(producerPaymentResponse.PreviousPaymentsReceived),
-            SubsidiaryFee = ConvertToPoundsFromPence(producerPaymentResponse.SubsidiaryFee - producerPaymentResponse.SubsidiariesFeeBreakdown.SubsidiaryOnlineMarketPlaceFee),
-            SubsidiaryOnlineMarketPlaceFee = ConvertToPoundsFromPence(producerPaymentResponse.SubsidiariesFeeBreakdown.SubsidiaryOnlineMarketPlaceFee),
+            SubsidiaryFee = ConvertToPoundsFromPence(producerPaymentResponse.SubsidiaryFee - subsidiaryOmpFee),
+            SubsidiaryOnlineMarketPlaceFee = ConvertToPoundsFromPence(subsidiaryOmpFee),
             SubTotal = ConvertToPoundsFromPence(producerPaymentResponse.TotalChargeableItems),
             TotalOutstanding = ConvertToPoundsFromPence(PaymentHelper.GetUpdatedTotalOutstanding(producerPaymentResponse.TotalOutstanding, options.Value.ShowZeroFeeForTotalOutstanding)),
-            ProducerSize = $"{char.ToUpperInvariant(viewModel.ProducerDetails.ProducerType[0])}{viewModel.ProducerDetails.ProducerType[1..]}",
-            NumberOfSubsidiaries = viewModel.ProducerDetails.NoOfSubsidiaries,
-            NumberOfSubsidiariesBeingOnlineMarketplace = producerPaymentResponse.SubsidiariesFeeBreakdown.OnlineMarketPlaceSubsidiariesCount,
+            ProducerSize = producerType.Length > 0 ? $"{char.ToUpperInvariant(producerType[0])}{producerType[1..]}" : string.Empty,
+            NumberOfSubsidiaries = producerDetails?.NoOfSubsidiaries ?? 0,
+            NumberOfSubsidiariesBeingOnlineMarketplace = subsidiariesBreakdown?.OnlineMarketPlaceSubsidiariesCount ?? 0,
             ResubmissionStatus = viewModel.ResubmissionStatus,
             Status = viewModel.Status,
         };

--- a/src/Epr.RegulatorService.sln
+++ b/src/Epr.RegulatorService.sln
@@ -58,6 +58,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntegrationTests", "Integra
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MockRegulatorFacade", "MockRegulatorFacade\MockRegulatorFacade.csproj", "{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MockPaymentFacade", "MockPaymentFacade\MockPaymentFacade.csproj", "{542D3337-0A9F-4808-898F-D2E7D36A4625}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -84,6 +86,10 @@ Global
 		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-E5F6-47A8-B9C0-D1E2F3A4B5C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{542D3337-0A9F-4808-898F-D2E7D36A4625}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{542D3337-0A9F-4808-898F-D2E7D36A4625}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{542D3337-0A9F-4808-898F-D2E7D36A4625}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{542D3337-0A9F-4808-898F-D2E7D36A4625}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/IntegrationTests/Infrastructure/RegulatorServiceWebApplicationFactory.cs
+++ b/src/IntegrationTests/Infrastructure/RegulatorServiceWebApplicationFactory.cs
@@ -15,8 +15,10 @@ using WireMock.Server;
 public class RegulatorServiceWebApplicationFactory : WebApplicationFactory<Program>
 {
     private readonly WireMockServer _facadeServer = MockRegulatorFacade.MockRegulatorFacadeServer.Start(useSsl: true);
+    private readonly WireMockServer _paymentFacadeServer = MockPaymentFacade.MockPaymentFacadeServer.Start(useSsl: true);
 
     public WireMockServer FacadeServer => _facadeServer;
+    public WireMockServer PaymentFacadeServer => _paymentFacadeServer;
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
@@ -30,6 +32,7 @@ public class RegulatorServiceWebApplicationFactory : WebApplicationFactory<Progr
 
         Environment.SetEnvironmentVariable("FacadeApi__BaseUrl", $"{_facadeServer.Url}/api/");
         Environment.SetEnvironmentVariable("EprAuthorizationConfig__FacadeBaseUrl", $"{_facadeServer.Url}/api/");
+        Environment.SetEnvironmentVariable("PaymentFacadeApi__BaseUrl", $"{_paymentFacadeServer.Url}/");
         Environment.SetEnvironmentVariable("UseLocalSession", "true");
 
         builder.ConfigureTestServices(services =>
@@ -66,6 +69,8 @@ public class RegulatorServiceWebApplicationFactory : WebApplicationFactory<Progr
         {
             _facadeServer?.Stop();
             _facadeServer?.Dispose();
+            _paymentFacadeServer?.Stop();
+            _paymentFacadeServer?.Dispose();
         }
         base.Dispose(disposing);
     }

--- a/src/IntegrationTests/IntegrationTests.csproj
+++ b/src/IntegrationTests/IntegrationTests.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <ProjectReference Include="../EPR.RegulatorService.Frontend.Web/EPR.RegulatorService.Frontend.Web.csproj" />
     <ProjectReference Include="..\MockRegulatorFacade\MockRegulatorFacade.csproj" />
+    <ProjectReference Include="..\MockPaymentFacade\MockPaymentFacade.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/MockPaymentFacade/MockPaymentFacade.csproj
+++ b/src/MockPaymentFacade/MockPaymentFacade.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <SonarQubeExclude>true</SonarQubeExclude>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WireMock.Net.StandAlone" Version="1.5.54" />
+  </ItemGroup>
+
+</Project>

--- a/src/MockPaymentFacade/MockPaymentFacadeServer.cs
+++ b/src/MockPaymentFacade/MockPaymentFacadeServer.cs
@@ -1,0 +1,32 @@
+namespace MockPaymentFacade;
+
+using System.Diagnostics.CodeAnalysis;
+
+using PaymentApi;
+
+using WireMock.Logging;
+using WireMock.Net.StandAlone;
+using WireMock.Server;
+using WireMock.Settings;
+
+[ExcludeFromCodeCoverage]
+public static class MockPaymentFacadeServer
+{
+    public static WireMockServer Start(int? port = null, bool useSsl = false)
+    {
+        var settings = new WireMockServerSettings
+        {
+            UseSSL = useSsl,
+            Logger = new WireMockConsoleLogger()
+        };
+        if (port.HasValue)
+        {
+            settings.Port = port.Value;
+        }
+
+        var server = StandAloneApp.Start(settings)
+            .WithPaymentApi();
+
+        return server;
+    }
+}

--- a/src/MockPaymentFacade/PaymentApi/PaymentApi.cs
+++ b/src/MockPaymentFacade/PaymentApi/PaymentApi.cs
@@ -1,0 +1,111 @@
+namespace MockPaymentFacade.PaymentApi;
+
+using System.Text.Json;
+
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+public static class PaymentApi
+{
+    public static WireMockServer WithPaymentApi(this WireMockServer server)
+    {
+        // Root endpoint to show something helpful in the browser when run with launchSettings
+        server.Given(Request.Create()
+                .UsingGet()
+                .WithPath("/"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "text/plain")
+                .WithBody("MockPaymentFacade up.\nReady to process API requests."));
+
+        // Compliance scheme registration fee endpoint
+        server.Given(Request.Create()
+                .UsingPost()
+                .WithPath("/compliance-scheme/registration-fee"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(JsonSerializer.Serialize(new
+                {
+                    complianceSchemeRegistrationFee = 262000,
+                    totalFee = 165800,
+                    previousPayment = 0,
+                    outstandingPayment = 165800,
+                    complianceSchemeMembersWithFees = new[]
+                    {
+                        new
+                        {
+                            memberId = "100001",
+                            memberType = "large",
+                            memberRegistrationFee = 165800,
+                            memberOnlineMarketPlaceFee = 0,
+                            memberLateRegistrationFee = 0,
+                            subsidiariesFee = 0,
+                            totalMemberFee = 165800
+                        }
+                    }
+                })));
+
+        // Producer registration fee endpoint
+        server.Given(Request.Create()
+                .UsingPost()
+                .WithPath("/producer/registration-fee"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(JsonSerializer.Serialize(new
+                {
+                    producerRegistrationFee = 165800,
+                    producerOnlineMarketPlaceFee = 0,
+                    producerLateRegistrationFee = 0,
+                    totalFee = 165800,
+                    previousPayment = 0,
+                    outstandingPayment = 165800,
+                    subsidiariesFee = 0,
+                    subsidiariesFeeBreakdown = new
+                    {
+                        totalSubsidiariesOMPFees = 0,
+                        countOfOMPSubsidiaries = 0
+                    }
+                })));
+
+        // Offline payments endpoint
+        server.Given(Request.Create()
+                .UsingPost()
+                .WithPath("/offline-payments"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(200));
+
+        // Producer resubmission fee endpoint
+        server.Given(Request.Create()
+                .UsingPost()
+                .WithPath("/producer/resubmission-fee"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(JsonSerializer.Serialize(new
+                {
+                    producerResubmissionFee = 0,
+                    previousPayment = 0,
+                    outstandingPayment = 0
+                })));
+
+        // Compliance scheme resubmission fees endpoint
+        server.Given(Request.Create()
+                .UsingPost()
+                .WithPath("/compliance-scheme/resubmission-fees"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(JsonSerializer.Serialize(new
+                {
+                    totalResubmissionFee = 0,
+                    previousPayment = 0,
+                    outstandingPayment = 0,
+                    memberResubmissionFees = Array.Empty<object>()
+                })));
+
+        return server;
+    }
+}

--- a/src/MockPaymentFacade/Program.cs
+++ b/src/MockPaymentFacade/Program.cs
@@ -1,0 +1,8 @@
+using MockPaymentFacade;
+
+Console.WriteLine("Starting Mock Payment Facade Server...");
+var server = MockPaymentFacadeServer.Start(port: 7107, useSsl: true);
+Console.WriteLine($"Mock Payment Facade running at: {server.Url}");
+Console.WriteLine("Press any key to stop...");
+Console.ReadKey();
+server.Stop();

--- a/src/MockPaymentFacade/Properties/launchSettings.json
+++ b/src/MockPaymentFacade/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "MockPaymentFacade": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "https://localhost:7107"
+    }
+  }
+}


### PR DESCRIPTION
Remove all error hiding

Patch best viewed with whitespace ignored due to re-indentation.

A large amount of the code in this service was wrapped in try-catch-log that prevented the proper propagation of errors, resulting in misleading behaviour in the frontend including duplicate error/redirect logic that should be handled by the generic error handlers.

The regulator frontend code is riddled with try-catch-log blocks of code that obscure the actual behaviour, make troubleshooting hard, cause the service to behave in unexpected or incorrect ways, and duplicate the behaviour of the global error handlers.

Having tripped over and fixed a small number of these we can now eliminate all the rest and save our future selves a lot of head scratching and wasted time.

https://eaflood.atlassian.net/browse/SMAL-361


- **Remove all error hiding**
- **Fix claim handling for edge cases**
- **Update unit tests to expect failure when something breaks**
- **Add payment mock setup to integration tests**
- **Fix null-ref exceptions in payment response handling**
