### PR TITLE
AMCR-147: SQL Injection warnings from Submissions action — post jsonSubmission in form body (INC2460894)

### DIFF
--- a/src/EPR.RegulatorService.Frontend.Web/Views/Shared/Components/SubmissionsList/Default.cshtml
+++ b/src/EPR.RegulatorService.Frontend.Web/Views/Shared/Components/SubmissionsList/Default.cshtml
@@ -35,8 +35,9 @@
                     <td role="gridcell" class="govuk-table__cell vertical-middle-align">
                         <span class="responsive-table__heading" aria-hidden="true">@Localizer["Table.Header.Organisation"]</span>
 
-                    @using (Html.BeginForm("Submissions", "Submissions", new { jsonSubmission = JsonSerializer.Serialize(submission) }, FormMethod.Post))
+                    @using (Html.BeginForm("Submissions", "Submissions", FormMethod.Post))
                     {
+                        <input type="hidden" name="jsonSubmission" value="@JsonSerializer.Serialize(submission)" />
                         <button class="govuk-link link-button-active" type="submit">
                             @submission.OrganisationName
                         </button>

--- a/src/IntegrationTests/Features/SubmissionsTests.cs
+++ b/src/IntegrationTests/Features/SubmissionsTests.cs
@@ -1,8 +1,13 @@
 namespace IntegrationTests.Features;
 
+using System.Net;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using AwesomeAssertions;
 using AwesomeAssertions.Execution;
+using EPR.RegulatorService.Frontend.Core.Enums;
+using EPR.RegulatorService.Frontend.Core.Models.Submissions;
+using EPR.RegulatorService.Frontend.Web.Constants;
 using IntegrationTests.Builders;
 using IntegrationTests.Infrastructure;
 using IntegrationTests.PageModels;
@@ -42,6 +47,63 @@ public class SubmissionsTests : IntegrationTestBase
             page.PageHeading.Should().Be(expectedHeading);
         }
     }
+
+    /// <summary>
+    /// Smoke test: model binding must accept <c>jsonSubmission</c> from the POST body (hidden field),
+    /// not only from the query string — see AMCR-147 / WAF.
+    /// </summary>
+    [Fact]
+    public async Task Submissions_Post_WithJsonSubmissionInFormBody_RedirectsToSubmissionDetails()
+    {
+        SetupUserAccountsMock();
+        SetupFacadeMockPomSubmissions([]);
+
+        var submission = CreateSampleSubmission();
+        var json = JsonSerializer.Serialize(submission);
+
+        using var client = CreateNoRedirectClient();
+        await client.GetAsync("/regulators/manage-packaging-data-submissions");
+
+        using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["jsonSubmission"] = json,
+        });
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
+
+        var postUri = "/regulators/manage-packaging-data-submissions";
+        postUri.Should().NotContain("jsonSubmission", "POST URL must not carry jsonSubmission in the query string");
+
+        using var response = await client.PostAsync(postUri, content);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Redirect);
+        response.Headers.Location.Should().NotBeNull();
+        response.Headers.Location!.ToString().Should().Contain("submissionHash", "expected redirect to submission details with hash");
+        response.Headers.Location!.ToString().Should().Contain(PagePath.SubmissionDetails);
+    }
+
+    private static Submission CreateSampleSubmission() =>
+        new()
+        {
+            SubmissionId = Guid.Parse("a3f6c7b8-9d4e-4f9a-bcde-1234567890ab"),
+            SubmittedDate = new DateTime(2023, 10, 30, 10, 51, 23, DateTimeKind.Utc),
+            Decision = SubmissionStatus.Pending,
+            IsResubmission = false,
+            IsResubmissionRequired = false,
+            Comments = string.Empty,
+            OrganisationId = Guid.Parse("d4e5f6a7-b8c9-0d1e-2f3a-9876543210cd"),
+            OrganisationName = "Integration Test Org Ltd",
+            OrganisationType = OrganisationType.DirectProducer,
+            OrganisationReference = "REF123",
+            UserId = Guid.Parse("e1e2e3e4-f5a6-47b8-9c0d-1e2f3a4b5c6d"),
+            Email = "regulator@test.example",
+            FirstName = "Test",
+            LastName = "Regulator",
+            Telephone = "01234567890",
+            ServiceRole = "Approved person",
+            FileId = Guid.Parse("f1f2f3f4-a5b6-47c8-9d0e-1f2a3b4c5d6e"),
+            PomBlobName = "blob-name",
+            PomFileName = "pom.csv",
+        };
 
     private void SetupFacadeMockPomSubmissions(object[] data) =>
         FacadeServer.Given(Request.Create()

--- a/src/IntegrationTests/Infrastructure/IntegrationTestBase.cs
+++ b/src/IntegrationTests/Infrastructure/IntegrationTestBase.cs
@@ -3,6 +3,7 @@ namespace IntegrationTests.Infrastructure;
 using System.Text.Json;
 
 using IntegrationTests.Builders;
+using Microsoft.AspNetCore.Mvc.Testing;
 using PageModels;
 
 using WireMock.RequestBuilders;
@@ -11,7 +12,7 @@ using WireMock.Server;
 
 public abstract class IntegrationTestBase : IAsyncLifetime
 {
-    private RegulatorServiceWebApplicationFactory Factory { get; set; } = null!;
+    protected RegulatorServiceWebApplicationFactory Factory { get; private set; } = null!;
     protected HttpClient Client { get; private set; } = null!;
     protected WireMockServer FacadeServer => Factory.FacadeServer;
 
@@ -28,6 +29,10 @@ public abstract class IntegrationTestBase : IAsyncLifetime
         Client.Dispose();
         await Factory.DisposeAsync();
     }
+
+    /// <summary>HTTP client that does not follow redirects (e.g. assert 302 Location for form posts).</summary>
+    protected HttpClient CreateNoRedirectClient() =>
+        Factory.CreateClient(new WebApplicationFactoryClientOptions { AllowAutoRedirect = false });
 
     protected void SetupUserAccountsMock() =>
         SetupUserAccountsMock(UserAccountBuilder.Default());


### PR DESCRIPTION
## What
- Stop putting serialized submission JSON on the form **action** URL via `BeginForm` route values (query string).
- Post `jsonSubmission` as a **hidden input** in the POST body instead.

## Why
WAF was blocking or flagging requests (INC2460894) because the query string resembled SQL injection patterns.

## Ticket
- https://eaflood.atlassian.net/browse/AMCR-147
