### PR TITLE
fix(automapper): apply MaxDepth(64) to mitigate recursive mapping vulnerability

### DIFF
--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/Extensions/ServiceProviderExtensionTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/Extensions/ServiceProviderExtensionTests.cs
@@ -1,6 +1,10 @@
+using AutoMapper;
+using AutoMapper.Internal;
+
 using EPR.RegulatorService.Frontend.Core.Configs;
 using EPR.RegulatorService.Frontend.Web.Configs;
 using EPR.RegulatorService.Frontend.Web.Extensions;
+using EPR.RegulatorService.Frontend.Web.Mappings;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -65,5 +69,26 @@ public class ServiceProviderExtensionTests
         // Assert
         Assert.IsNotNull(services);
         services.Count.Should().BeGreaterThan(0);
+    }
+
+    [TestMethod]
+    public void RegisterAutoMapper_ShouldApplyMaxDepthToAllMaps()
+    {
+        // Arrange
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.Internal().ForAllMaps((_, mapping) => mapping.MaxDepth(64));
+            cfg.AddMaps(typeof(ManageRegistrationsMappingProfile).Assembly);
+        });
+
+        // Act
+        var typeMaps = config.Internal().GetAllTypeMaps();
+
+        // Assert
+        typeMaps.Should().NotBeEmpty();
+        foreach (var typeMap in typeMaps)
+        {
+            typeMap.MaxDepth.Should().Be(64, $"MaxDepth should be 64 for {typeMap.SourceType.Name} -> {typeMap.DestinationType.Name}");
+        }
     }
 }

--- a/src/EPR.RegulatorService.Frontend.Web/Extensions/ServiceProviderExtension.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Extensions/ServiceProviderExtension.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 
+using AutoMapper;
+using AutoMapper.Internal;
+
 using EPR.Common.Authorization.Extensions;
 using EPR.RegulatorService.Frontend.Core.Configs;
 using EPR.RegulatorService.Frontend.Core.Sessions;
@@ -220,6 +223,12 @@ public static class ServiceProviderExtension
 
     private static void RegisterAutoMapper(IServiceCollection services)
     {
-        services.AddAutoMapper(typeof(ManageRegistrationsMappingProfile));
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.Internal().ForAllMaps((_, mapping) => mapping.MaxDepth(64));
+            cfg.AddMaps(typeof(ManageRegistrationsMappingProfile).Assembly);
+        });
+
+        services.AddSingleton<IMapper>(config.CreateMapper());
     }
 }


### PR DESCRIPTION
## What
Capping recursion depth at 64 mitigates this until the long-term removal of AutoMapper is completed.

## Why
AutoMapper v14 is vulnerable to stack overflow via deeply nested or self-referencing object graphs.

## Ticket url
- https://eaflood.atlassian.net/browse/AMCR-0000
