### PR TITLE
Add default redis connection string for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -372,12 +372,9 @@ src/certs/kainos-chain.pem
 src/certs/kainos-chain.p7b
 # Ignore all .sln files in subfolders of ./src
 /src/**/*.sln
-/src/**/appsettings.development.json
 
 # But do not ignore the .sln file in the ./src folder itself
 !/src/*.sln
 
 # these should be redundant
-/src/EPR.RegulatorService.Frontend.Web/appsettings.Development.json
-/src/EPR.RegulatorService.Frontend.Web/appsettings.development.json
 /src/EPR.RegulatorService.Frontend.Web/out

--- a/src/EPR.RegulatorService.Frontend.Web/appsettings.Development.json
+++ b/src/EPR.RegulatorService.Frontend.Web/appsettings.Development.json
@@ -1,0 +1,5 @@
+{
+    "ConnectionStrings": {
+        "REDIS_CONNECTION": "localhost:6379"
+    }
+}


### PR DESCRIPTION
## What

Add default redis connection string for **local development** only

## Why

Convenience, one less "secret" to set.

This file is ignored in production mode, and will be overridden by environment variables if set.

Tripped over this (yet again) while setting up in a different dev VM)