### PR TITLE
ACMR-291 Update CLR fee calculation logic and tests

### DIFF
--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/Extensions/ComplianceSchemeMemberExtensionTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/Extensions/ComplianceSchemeMemberExtensionTests.cs
@@ -7,7 +7,6 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Extensions;
 public class ComplianceSchemeMemberExtensionTests
 {
     [TestMethod]
-    [Ignore("Temporary: SubsidiariesFeeBreakdown excluded from GetNetSubsidiariesCompanyFees")]
     public void GetNetSubsidiariesCompanyFees_SumsNetFeesForMembersWithSubsidiaryFee()
     {
         var members = new List<ComplianceSchemeMember>
@@ -96,7 +95,7 @@ public class ComplianceSchemeMemberExtensionTests
     }
 
     [TestMethod]
-    public void GetClosedLoopRecyclingFee_ReturnsMaxFeeWhenMembersHaveClosedLoopFees()
+    public void GetClosedLoopRecyclingFees_ReturnsFeesForMembersWithClosedLoopFees()
     {
         var members = new List<ComplianceSchemeMember>
         {
@@ -105,25 +104,53 @@ public class ComplianceSchemeMemberExtensionTests
             new() { ClosedLoopRecyclingFee = 0m }
         };
 
-        members.GetClosedLoopRecyclingFee().Should().Be(30_000m);
+        members.GetClosedLoopRecyclingFees().Should().BeEquivalentTo([20_000m, 30_000m]);
     }
 
     [TestMethod]
-    public void GetClosedLoopRecyclingFee_ReturnsZeroWhenNoMembersHaveClosedLoopFees()
+    public void GetClosedLoopRecyclingFees_ReturnsEmptyListWhenNoMembersHaveClosedLoopFees()
     {
         var members = new List<ComplianceSchemeMember>
         {
             new() { ClosedLoopRecyclingFee = 0m }
         };
 
-        members.GetClosedLoopRecyclingFee().Should().Be(0m);
+        members.GetClosedLoopRecyclingFees().Should().BeEmpty();
     }
 
     [TestMethod]
-    public void GetClosedLoopRecyclingFee_ReturnsZeroWhenMembersListIsEmpty()
+    public void GetClosedLoopRecyclingFees_ReturnsEmptyListWhenMembersListIsEmpty()
     {
         var members = new List<ComplianceSchemeMember>();
 
-        members.GetClosedLoopRecyclingFee().Should().Be(0m);
+        members.GetClosedLoopRecyclingFees().Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void GetSubsidiariesOnlineMarketPlaceFees_SumsFeesAndTreatsNullBreakdownAsZero()
+    {
+        var members = new List<ComplianceSchemeMember>
+        {
+            new()
+            {
+                SubsidiariesFeeBreakdown = new SubsidiariesFeeBreakdownResponse
+                {
+                    SubsidiaryOnlineMarketPlaceFee = 20_000m
+                }
+            },
+            new()
+            {
+                SubsidiariesFeeBreakdown = new SubsidiariesFeeBreakdownResponse
+                {
+                    SubsidiaryOnlineMarketPlaceFee = 30_000m
+                }
+            },
+            new()
+            {
+                SubsidiariesFeeBreakdown = null
+            }
+        };
+
+        members.GetSubsidiariesOnlineMarketPlaceFees().Should().Be(50_000m);
     }
 }

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/Extensions/ComplianceSchemeMemberExtensionTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/Extensions/ComplianceSchemeMemberExtensionTests.cs
@@ -7,6 +7,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Web.Extensions;
 public class ComplianceSchemeMemberExtensionTests
 {
     [TestMethod]
+    [Ignore("Temporary: SubsidiariesFeeBreakdown excluded from GetNetSubsidiariesCompanyFees")]
     public void GetNetSubsidiariesCompanyFees_SumsNetFeesForMembersWithSubsidiaryFee()
     {
         var members = new List<ComplianceSchemeMember>
@@ -92,5 +93,37 @@ public class ComplianceSchemeMemberExtensionTests
         };
 
         members.GetSubsidiariesClosedLoopRecyclingFees().Should().Be(50_000m);
+    }
+
+    [TestMethod]
+    public void GetClosedLoopRecyclingFee_ReturnsMaxFeeWhenMembersHaveClosedLoopFees()
+    {
+        var members = new List<ComplianceSchemeMember>
+        {
+            new() { ClosedLoopRecyclingFee = 20_000m },
+            new() { ClosedLoopRecyclingFee = 30_000m },
+            new() { ClosedLoopRecyclingFee = 0m }
+        };
+
+        members.GetClosedLoopRecyclingFee().Should().Be(30_000m);
+    }
+
+    [TestMethod]
+    public void GetClosedLoopRecyclingFee_ReturnsZeroWhenNoMembersHaveClosedLoopFees()
+    {
+        var members = new List<ComplianceSchemeMember>
+        {
+            new() { ClosedLoopRecyclingFee = 0m }
+        };
+
+        members.GetClosedLoopRecyclingFee().Should().Be(0m);
+    }
+
+    [TestMethod]
+    public void GetClosedLoopRecyclingFee_ReturnsZeroWhenMembersListIsEmpty()
+    {
+        var members = new List<ComplianceSchemeMember>();
+
+        members.GetClosedLoopRecyclingFee().Should().Be(0m);
     }
 }

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/CompliancePaymentDetailsViewComponentTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/CompliancePaymentDetailsViewComponentTests.cs
@@ -304,7 +304,7 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
     }
 
     [TestMethod]
-    public async Task InvokeAsync_DoesNotSetIsClosedLoopRecycling_WhenMemberHasHoldingCompanyClrButNoSubsidiaries()
+    public async Task InvokeAsync_SetsIsClosedLoopRecycling_WhenMemberHasHoldingCompanyClrButNoSubsidiaries()
     {
         // Arrange
         CompliancePaymentRequest? capturedRequest = null;
@@ -334,7 +334,48 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
         capturedRequest.Should().NotBeNull();
         var members = capturedRequest!.ComplianceSchemeMembers!.ToList();
         members[0].NoOfHoldingCompaniesClosedLoopRecycling.Should().Be(1);
-        members[0].IsClosedLoopRecycling.Should().BeFalse();
+        members[0].IsClosedLoopRecycling.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_SetsIsClosedLoopRecycling_ForFirstNLargeMembers_WhenMultipleHoldingCompaniesHaveClr()
+    {
+        // Arrange
+        CompliancePaymentRequest? capturedRequest = null;
+        _registrationSumissionDetailsViewModel.RegistrationJourneyType = RegistrationJourneyType.CsoLargeProducer;
+        _registrationSumissionDetailsViewModel.CSOMembershipDetails =
+        [
+            new CsoMembershipDetailsDto { MemberId = "member1", MemberType = "large", NumberOfHoldingCompaniesClosedLoopRecycling = 3 },
+            new CsoMembershipDetailsDto { MemberId = "member2", MemberType = "large", NumberOfHoldingCompaniesClosedLoopRecycling = 3 },
+            new CsoMembershipDetailsDto { MemberId = "member3", MemberType = "large", NumberOfHoldingCompaniesClosedLoopRecycling = 3 },
+            new CsoMembershipDetailsDto { MemberId = "member4", MemberType = "large", NumberOfHoldingCompaniesClosedLoopRecycling = 3 },
+            new CsoMembershipDetailsDto { MemberId = "member5", MemberType = "small", NumberOfHoldingCompaniesClosedLoopRecycling = 3 }
+        ];
+        _registrationSumissionDetailsViewModel.SubmissionDetails = new SubmissionDetailsViewModel
+        {
+            TimeAndDateOfSubmission = DateTime.UtcNow.AddDays(-1)
+        };
+        _paymentFacadeServiceMock.Setup(x => x.GetCompliancePaymentDetailsAsync(It.IsAny<CompliancePaymentRequest>()))
+            .Callback<CompliancePaymentRequest>(r => capturedRequest = r)
+            .ReturnsAsync((CompliancePaymentResponse?)null);
+
+        // Act
+        await _sut.InvokeAsync(_registrationSumissionDetailsViewModel);
+
+        // Assert
+        capturedRequest.Should().NotBeNull();
+        var members = capturedRequest!.ComplianceSchemeMembers!.ToList();
+        members.Should().HaveCount(5);
+        members[0].IsClosedLoopRecycling.Should().BeTrue();
+        members[0].NoOfHoldingCompaniesClosedLoopRecycling.Should().Be(1);
+        members[1].IsClosedLoopRecycling.Should().BeTrue();
+        members[1].NoOfHoldingCompaniesClosedLoopRecycling.Should().Be(1);
+        members[2].IsClosedLoopRecycling.Should().BeTrue();
+        members[2].NoOfHoldingCompaniesClosedLoopRecycling.Should().Be(1);
+        members[3].IsClosedLoopRecycling.Should().BeFalse();
+        members[3].NoOfHoldingCompaniesClosedLoopRecycling.Should().Be(0);
+        members[4].IsClosedLoopRecycling.Should().BeFalse();
+        members[4].NoOfHoldingCompaniesClosedLoopRecycling.Should().Be(0);
     }
 
     [TestMethod]

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/CompliancePaymentDetailsViewComponentTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/CompliancePaymentDetailsViewComponentTests.cs
@@ -147,7 +147,8 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public async Task InvokeAsync_Passes_NumberOfSubsidiariesClosedLoopRecycling_ToPaymentFacade(bool isResubmission)
+    public async Task InvokeAsync_Passes_HoldingCompanyClosedLoopRecycling_And_Zeros_SubsidiariesClosedLoopRecycling_For_CsoLargeProducer(
+        bool isResubmission)
     {
         // Arrange
         CompliancePaymentRequest? capturedRequest = null;
@@ -162,6 +163,7 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
                 MemberId = "memberid1",
                 MemberType = "large",
                 NumberOfHoldingCompaniesClosedLoopRecycling = 1,
+                NumberOfSubsidiaries = 1,
                 NumberOfSubsidiariesClosedLoopRecycling = 7
             }
         ];
@@ -191,8 +193,8 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
         capturedRequest.Should().NotBeNull();
         var members = capturedRequest!.ComplianceSchemeMembers!.ToList();
         members.Should().ContainSingle();
-        members[0].NoOfSubsidiariesClosedLoopRecycling.Should().Be(7);
         members[0].NoOfHoldingCompaniesClosedLoopRecycling.Should().Be(1);
+        members[0].NoOfSubsidiariesClosedLoopRecycling.Should().Be(0);
         members[0].IsClosedLoopRecycling.Should().BeTrue();
     }
 
@@ -302,6 +304,7 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
     }
 
     [TestMethod]
+    [Ignore("Temporary: SubsidiariesFeeBreakdown excluded from GetNetSubsidiariesCompanyFees")]
     public async Task InvokeAsync_SubsidiariesCompanyFee_Excludes_Omp_And_Clr_From_SubsidiariesFee()
     {
         // Arrange

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/CompliancePaymentDetailsViewComponentTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/CompliancePaymentDetailsViewComponentTests.cs
@@ -304,7 +304,40 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
     }
 
     [TestMethod]
-    [Ignore("Temporary: SubsidiariesFeeBreakdown excluded from GetNetSubsidiariesCompanyFees")]
+    public async Task InvokeAsync_DoesNotSetIsClosedLoopRecycling_WhenMemberHasHoldingCompanyClrButNoSubsidiaries()
+    {
+        // Arrange
+        CompliancePaymentRequest? capturedRequest = null;
+        _registrationSumissionDetailsViewModel.RegistrationJourneyType = RegistrationJourneyType.CsoLargeProducer;
+        _registrationSumissionDetailsViewModel.CSOMembershipDetails =
+        [
+            new CsoMembershipDetailsDto
+            {
+                MemberId = "memberid1",
+                MemberType = "large",
+                NumberOfHoldingCompaniesClosedLoopRecycling = 1,
+                NumberOfSubsidiaries = 0
+            }
+        ];
+        _registrationSumissionDetailsViewModel.SubmissionDetails = new SubmissionDetailsViewModel
+        {
+            TimeAndDateOfSubmission = DateTime.UtcNow.AddDays(-1)
+        };
+        _paymentFacadeServiceMock.Setup(x => x.GetCompliancePaymentDetailsAsync(It.IsAny<CompliancePaymentRequest>()))
+            .Callback<CompliancePaymentRequest>(r => capturedRequest = r)
+            .ReturnsAsync((CompliancePaymentResponse?)null);
+
+        // Act
+        await _sut.InvokeAsync(_registrationSumissionDetailsViewModel);
+
+        // Assert
+        capturedRequest.Should().NotBeNull();
+        var members = capturedRequest!.ComplianceSchemeMembers!.ToList();
+        members[0].NoOfHoldingCompaniesClosedLoopRecycling.Should().Be(1);
+        members[0].IsClosedLoopRecycling.Should().BeFalse();
+    }
+
+    [TestMethod]
     public async Task InvokeAsync_SubsidiariesCompanyFee_Excludes_Omp_And_Clr_From_SubsidiariesFee()
     {
         // Arrange

--- a/src/EPR.RegulatorService.Frontend.Web/Extensions/ComplianceSchemeMemberExtension.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Extensions/ComplianceSchemeMemberExtension.cs
@@ -2,7 +2,6 @@ namespace EPR.RegulatorService.Frontend.Web.Extensions;
 
 using EPR.RegulatorService.Frontend.Core.Models.RegistrationSubmissions;
 using EPR.RegulatorService.Frontend.Core.Models.RegistrationSubmissions.FacadeCommonData;
-using EPR.RegulatorService.Frontend.Web.Helpers;
 
 internal static class ComplianceSchemeMemberExtension
 {
@@ -46,9 +45,7 @@ internal static class ComplianceSchemeMemberExtension
     internal static decimal GetNetSubsidiariesCompanyFees(this List<ComplianceSchemeMember> complianceSchemeMembers) =>
         complianceSchemeMembers
             .Where(r => r.SubsidiaryFee > 0)
-            .Sum(r => SubsidiaryFeeHelper.GetNetSubsidiaryCompaniesFee(
-                r.SubsidiaryFee,
-                r.SubsidiariesFeeBreakdown));
+            .Sum(r => r.SubsidiaryFee);
 
     internal static int GetSubsidiariesClosedLoopRecyclingCount(this List<ComplianceSchemeMember> complianceSchemeMembers) =>
         complianceSchemeMembers.Sum(r => r.SubsidiariesFeeBreakdown?.CountOfClosedLoopRecyclingSubsidiaries ?? 0);
@@ -56,6 +53,10 @@ internal static class ComplianceSchemeMemberExtension
     internal static decimal GetSubsidiariesClosedLoopRecyclingFees(this List<ComplianceSchemeMember> complianceSchemeMembers) =>
         complianceSchemeMembers.Sum(r => r.SubsidiariesFeeBreakdown?.TotalSubsidiariesClosedLoopRecyclingFees ?? 0);
 
-    internal static IList<decimal> GetClosedLoopRecyclingFees(this List<ComplianceSchemeMember> complianceSchemeMembers) =>
-        complianceSchemeMembers.Where(r => r.ClosedLoopRecyclingFee > 0).Select(r => r.ClosedLoopRecyclingFee).ToList();
+    internal static decimal GetClosedLoopRecyclingFee(this List<ComplianceSchemeMember> complianceSchemeMembers) =>
+        complianceSchemeMembers
+            .Where(r => r.ClosedLoopRecyclingFee > 0)
+            .Select(r => r.ClosedLoopRecyclingFee)
+            .DefaultIfEmpty(0)
+            .Max();
 }

--- a/src/EPR.RegulatorService.Frontend.Web/Extensions/ComplianceSchemeMemberExtension.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/Extensions/ComplianceSchemeMemberExtension.cs
@@ -2,6 +2,7 @@ namespace EPR.RegulatorService.Frontend.Web.Extensions;
 
 using EPR.RegulatorService.Frontend.Core.Models.RegistrationSubmissions;
 using EPR.RegulatorService.Frontend.Core.Models.RegistrationSubmissions.FacadeCommonData;
+using EPR.RegulatorService.Frontend.Web.Helpers;
 
 internal static class ComplianceSchemeMemberExtension
 {
@@ -45,7 +46,9 @@ internal static class ComplianceSchemeMemberExtension
     internal static decimal GetNetSubsidiariesCompanyFees(this List<ComplianceSchemeMember> complianceSchemeMembers) =>
         complianceSchemeMembers
             .Where(r => r.SubsidiaryFee > 0)
-            .Sum(r => r.SubsidiaryFee);
+            .Sum(r => SubsidiaryFeeHelper.GetNetSubsidiaryCompaniesFee(
+                r.SubsidiaryFee,
+                r.SubsidiariesFeeBreakdown));
 
     internal static int GetSubsidiariesClosedLoopRecyclingCount(this List<ComplianceSchemeMember> complianceSchemeMembers) =>
         complianceSchemeMembers.Sum(r => r.SubsidiariesFeeBreakdown?.CountOfClosedLoopRecyclingSubsidiaries ?? 0);
@@ -53,10 +56,12 @@ internal static class ComplianceSchemeMemberExtension
     internal static decimal GetSubsidiariesClosedLoopRecyclingFees(this List<ComplianceSchemeMember> complianceSchemeMembers) =>
         complianceSchemeMembers.Sum(r => r.SubsidiariesFeeBreakdown?.TotalSubsidiariesClosedLoopRecyclingFees ?? 0);
 
-    internal static decimal GetClosedLoopRecyclingFee(this List<ComplianceSchemeMember> complianceSchemeMembers) =>
-        complianceSchemeMembers
-            .Where(r => r.ClosedLoopRecyclingFee > 0)
-            .Select(r => r.ClosedLoopRecyclingFee)
-            .DefaultIfEmpty(0)
-            .Max();
+    internal static IList<decimal> GetClosedLoopRecyclingFees(this List<ComplianceSchemeMember> complianceSchemeMembers) =>
+        complianceSchemeMembers.Where(r => r.ClosedLoopRecyclingFee > 0).Select(r => r.ClosedLoopRecyclingFee).ToList();
+
+    internal static decimal GetSubsidiariesOnlineMarketPlaceFees(this List<ComplianceSchemeMember> complianceSchemeMembers) =>
+        complianceSchemeMembers.Sum(r => r.SubsidiariesFeeBreakdown?.SubsidiaryOnlineMarketPlaceFee ?? 0);
+
+    internal static int GetSubsidiariesOnlineMarketPlaceCount(this List<ComplianceSchemeMember> complianceSchemeMembers) =>
+        complianceSchemeMembers.Sum(r => r.SubsidiariesFeeBreakdown?.OnlineMarketPlaceSubsidiariesCount ?? 0);
 }

--- a/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/CompliancePaymentDetails/Default.cy.resx
+++ b/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/CompliancePaymentDetails/Default.cy.resx
@@ -216,4 +216,10 @@
   <data name="CompliancePaymentDetails.SubsidiaryClosedLoopRecyclingPluralDescription" xml:space="preserve">
     <value>Gwastraff pecynnu dolen gaeedig is-gwmnïau</value>
   </data>
+  <data name="CompliancePaymentDetails.SubsidiaryOnlineMarketPlaceSingularDescription" xml:space="preserve">
+    <value>Mae'r is-gwmni yn farchnad ar-lein</value>
+  </data>
+  <data name="CompliancePaymentDetails.SubsidiaryOnlineMarketPlacePluralDescription" xml:space="preserve">
+    <value>Mae'r is-gwmnïau yn farchnadoedd ar-lein</value>
+  </data>
 </root>

--- a/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/CompliancePaymentDetails/Default.en.resx
+++ b/src/EPR.RegulatorService.Frontend.Web/Resources/Views/Shared/Components/CompliancePaymentDetails/Default.en.resx
@@ -204,4 +204,10 @@
   <data name="CompliancePaymentDetails.SubsidiaryClosedLoopRecyclingPluralDescription" xml:space="preserve">
     <value>Subsidiaries closed loop packaging waste</value>
   </data>
+  <data name="CompliancePaymentDetails.SubsidiaryOnlineMarketPlaceSingularDescription" xml:space="preserve">
+    <value>Subsidiary is an online marketplace</value>
+  </data>
+  <data name="CompliancePaymentDetails.SubsidiaryOnlineMarketPlacePluralDescription" xml:space="preserve">
+    <value>Subsidiaries are online marketplaces</value>
+  </data>
 </root>

--- a/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/CompliancePaymentDetailsViewComponent.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/CompliancePaymentDetailsViewComponent.cs
@@ -53,6 +53,7 @@ public class CompliancePaymentDetailsViewComponent(
             var lateProducers = compliancePaymentResponse.ComplianceSchemeMembers.GetLateProducers();
             var onlineMarketPlaces = compliancePaymentResponse.ComplianceSchemeMembers.GetOnlineMarketPlaces();
             var complianceSchemeMembers = compliancePaymentResponse.ComplianceSchemeMembers;
+            var closedLoopRecyclingFees = complianceSchemeMembers.GetClosedLoopRecyclingFees();
 
             var compliancePaymentDetailsViewModel = new CompliancePaymentDetailsViewModel
             {
@@ -72,12 +73,15 @@ public class CompliancePaymentDetailsViewComponent(
                 LateProducerFee = ConvertToPoundsFromPence(lateProducers.Sum()),
                 OnlineMarketPlaceCount = onlineMarketPlaces.Count,
                 OnlineMarketPlaceFee = ConvertToPoundsFromPence(onlineMarketPlaces.Sum()),
-                ClosedLoopRegistrationCount = viewModel.ProducerDetails.NumberOfHoldingCompaniesClosedLoopRecycling,
-                ClosedLoopRecyclingFee =
-                    ConvertToPoundsFromPence(complianceSchemeMembers.GetClosedLoopRecyclingFee()),
+                ClosedLoopRegistrationCount = closedLoopRecyclingFees.Count,
+                ClosedLoopRecyclingFee = ConvertToPoundsFromPence(closedLoopRecyclingFees.Sum()),
                 SubsidiariesCompanyCount = csoMembers.Sum(r => r.NumberOfSubsidiaries),
                 SubsidiariesCompanyFee =
                     ConvertToPoundsFromPence(complianceSchemeMembers.GetNetSubsidiariesCompanyFees()),
+                SubsidiariesOnlineMarketPlaceCount =
+                    complianceSchemeMembers.GetSubsidiariesOnlineMarketPlaceCount(),
+                SubsidiariesOnlineMarketPlaceFee =
+                    ConvertToPoundsFromPence(complianceSchemeMembers.GetSubsidiariesOnlineMarketPlaceFees()),
                 SubsidiariesClosedLoopRecyclingCount =
                     complianceSchemeMembers.GetSubsidiariesClosedLoopRecyclingCount(),
                 SubsidiariesClosedLoopRecyclingFee =
@@ -122,7 +126,8 @@ public class CompliancePaymentDetailsViewComponent(
             IsOnlineMarketplace = csoMember.IsOnlineMarketPlace,
             IsLateFeeApplicable = csoMember.IsLateFeeApplicable,
             NoOfHoldingCompaniesClosedLoopRecycling = noOfHoldingCompaniesClosedLoopRecycling,
-            IsClosedLoopRecycling = (csoMember.NumberOfSubsidiaries > 0) && (csoMember.NumberOfHoldingCompaniesClosedLoopRecycling ?? 0) > 0,
+            IsClosedLoopRecycling = csoMember.NumberOfSubsidiaries > 0
+                && (csoMember.NumberOfHoldingCompaniesClosedLoopRecycling ?? 0) > 0,
             NoOfSubsidiariesClosedLoopRecycling = 0,
             NumberOfSubsidiaries = csoMember.NumberOfSubsidiaries,
             NoOfSubsidiariesOnlineMarketplace = csoMember.NumberOfSubsidiariesOnlineMarketPlace

--- a/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/CompliancePaymentDetailsViewComponent.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/CompliancePaymentDetailsViewComponent.cs
@@ -35,7 +35,7 @@ public class CompliancePaymentDetailsViewComponent(
                 {
                     ApplicationReferenceNumber = viewModel.ReferenceNumber,
                     Regulator = viewModel.NationCode,
-                    ComplianceSchemeMembers = csoMembers.Select(m => MapToComplianceSchemeMemberRequest(m, viewModel)),
+                    ComplianceSchemeMembers = MapToComplianceSchemeMemberRequests(csoMembers, viewModel),
                     SubmissionDate = TimeZoneInfo.ConvertTimeToUtc(viewModel.IsResubmission
                         ? viewModel.SubmissionDetails.TimeAndDateOfResubmission.GetValueOrDefault()
                         : viewModel.SubmissionDetails.TimeAndDateOfSubmission),
@@ -103,36 +103,43 @@ public class CompliancePaymentDetailsViewComponent(
         }
     }
 
-    private static ComplianceSchemeMemberRequest MapToComplianceSchemeMemberRequest(
-        CsoMembershipDetailsDto csoMember,
+    private static List<ComplianceSchemeMemberRequest> MapToComplianceSchemeMemberRequests(
+        IReadOnlyList<CsoMembershipDetailsDto> csoMembers,
         RegistrationSubmissionDetailsViewModel viewModel)
     {
-        bool isCsoLargeProducer = viewModel.RegistrationJourneyType == RegistrationJourneyType.CsoLargeProducer;
+        int holdingCompanyClosedLoopRecyclingCount =
+            viewModel.RegistrationJourneyType == RegistrationJourneyType.CsoLargeProducer && csoMembers.Count > 0
+                ? csoMembers[0].NumberOfHoldingCompaniesClosedLoopRecycling ?? 0
+                : 0;
 
-        int noOfHoldingCompaniesClosedLoopRecycling;
-        if (!isCsoLargeProducer)
-        {
-            noOfHoldingCompaniesClosedLoopRecycling = 0;
-        }
-        else
-        {
-            noOfHoldingCompaniesClosedLoopRecycling = csoMember.NumberOfHoldingCompaniesClosedLoopRecycling ?? 0;
-        }
+        return csoMembers
+            .Select((csoMember, index) => MapToComplianceSchemeMemberRequest(
+                csoMember,
+                IsHoldingCompanyClosedLoopRecyclingMember(csoMember, index, holdingCompanyClosedLoopRecyclingCount)))
+            .ToList();
+    }
 
-        return new ComplianceSchemeMemberRequest
+    private static bool IsHoldingCompanyClosedLoopRecyclingMember(
+        CsoMembershipDetailsDto csoMember,
+        int index,
+        int holdingCompanyClosedLoopRecyclingCount) =>
+        index < holdingCompanyClosedLoopRecyclingCount && csoMember is { MemberType: "large" };
+
+    private static ComplianceSchemeMemberRequest MapToComplianceSchemeMemberRequest(
+        CsoMembershipDetailsDto csoMember,
+        bool isClosedLoopRecycling) =>
+        new()
         {
             MemberId = csoMember.MemberId,
             MemberType = csoMember.MemberType,
             IsOnlineMarketplace = csoMember.IsOnlineMarketPlace,
             IsLateFeeApplicable = csoMember.IsLateFeeApplicable,
-            NoOfHoldingCompaniesClosedLoopRecycling = noOfHoldingCompaniesClosedLoopRecycling,
-            IsClosedLoopRecycling = csoMember is { MemberType: "large", NumberOfSubsidiaries: > 0 }
-                                    && (csoMember.NumberOfHoldingCompaniesClosedLoopRecycling ?? 0) > 0,
+            IsClosedLoopRecycling = isClosedLoopRecycling,
+            NoOfHoldingCompaniesClosedLoopRecycling = isClosedLoopRecycling ? 1 : 0,
             NoOfSubsidiariesClosedLoopRecycling = 0,
             NumberOfSubsidiaries = csoMember.NumberOfSubsidiaries,
             NoOfSubsidiariesOnlineMarketplace = csoMember.NumberOfSubsidiariesOnlineMarketPlace
         };
-    }
 
     private static decimal ConvertToPoundsFromPence(decimal amount) => amount / 100;
 }

--- a/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/CompliancePaymentDetailsViewComponent.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/CompliancePaymentDetailsViewComponent.cs
@@ -126,8 +126,8 @@ public class CompliancePaymentDetailsViewComponent(
             IsOnlineMarketplace = csoMember.IsOnlineMarketPlace,
             IsLateFeeApplicable = csoMember.IsLateFeeApplicable,
             NoOfHoldingCompaniesClosedLoopRecycling = noOfHoldingCompaniesClosedLoopRecycling,
-            IsClosedLoopRecycling = csoMember.NumberOfSubsidiaries > 0
-                && (csoMember.NumberOfHoldingCompaniesClosedLoopRecycling ?? 0) > 0,
+            IsClosedLoopRecycling = csoMember is { MemberType: "large", NumberOfSubsidiaries: > 0 }
+                                    && (csoMember.NumberOfHoldingCompaniesClosedLoopRecycling ?? 0) > 0,
             NoOfSubsidiariesClosedLoopRecycling = 0,
             NumberOfSubsidiaries = csoMember.NumberOfSubsidiaries,
             NoOfSubsidiariesOnlineMarketplace = csoMember.NumberOfSubsidiariesOnlineMarketPlace

--- a/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/CompliancePaymentDetailsViewComponent.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/CompliancePaymentDetailsViewComponent.cs
@@ -53,7 +53,6 @@ public class CompliancePaymentDetailsViewComponent(
             var lateProducers = compliancePaymentResponse.ComplianceSchemeMembers.GetLateProducers();
             var onlineMarketPlaces = compliancePaymentResponse.ComplianceSchemeMembers.GetOnlineMarketPlaces();
             var complianceSchemeMembers = compliancePaymentResponse.ComplianceSchemeMembers;
-            var closedLoopRecyclingFees = complianceSchemeMembers.GetClosedLoopRecyclingFees();
 
             var compliancePaymentDetailsViewModel = new CompliancePaymentDetailsViewModel
             {
@@ -73,8 +72,9 @@ public class CompliancePaymentDetailsViewComponent(
                 LateProducerFee = ConvertToPoundsFromPence(lateProducers.Sum()),
                 OnlineMarketPlaceCount = onlineMarketPlaces.Count,
                 OnlineMarketPlaceFee = ConvertToPoundsFromPence(onlineMarketPlaces.Sum()),
-                ClosedLoopRegistrationCount = closedLoopRecyclingFees.Count,
-                ClosedLoopRecyclingFee = ConvertToPoundsFromPence(closedLoopRecyclingFees.Sum()),
+                ClosedLoopRegistrationCount = viewModel.ProducerDetails.NumberOfHoldingCompaniesClosedLoopRecycling,
+                ClosedLoopRecyclingFee =
+                    ConvertToPoundsFromPence(complianceSchemeMembers.GetClosedLoopRecyclingFee()),
                 SubsidiariesCompanyCount = csoMembers.Sum(r => r.NumberOfSubsidiaries),
                 SubsidiariesCompanyFee =
                     ConvertToPoundsFromPence(complianceSchemeMembers.GetNetSubsidiariesCompanyFees()),
@@ -106,16 +106,13 @@ public class CompliancePaymentDetailsViewComponent(
         bool isCsoLargeProducer = viewModel.RegistrationJourneyType == RegistrationJourneyType.CsoLargeProducer;
 
         int noOfHoldingCompaniesClosedLoopRecycling;
-        int noOfSubsidiariesClosedLoopRecycling;
         if (!isCsoLargeProducer)
         {
             noOfHoldingCompaniesClosedLoopRecycling = 0;
-            noOfSubsidiariesClosedLoopRecycling = 0;
         }
         else
         {
             noOfHoldingCompaniesClosedLoopRecycling = csoMember.NumberOfHoldingCompaniesClosedLoopRecycling ?? 0;
-            noOfSubsidiariesClosedLoopRecycling = csoMember.NumberOfSubsidiariesClosedLoopRecycling;
         }
 
         return new ComplianceSchemeMemberRequest
@@ -125,8 +122,8 @@ public class CompliancePaymentDetailsViewComponent(
             IsOnlineMarketplace = csoMember.IsOnlineMarketPlace,
             IsLateFeeApplicable = csoMember.IsLateFeeApplicable,
             NoOfHoldingCompaniesClosedLoopRecycling = noOfHoldingCompaniesClosedLoopRecycling,
-            IsClosedLoopRecycling = noOfHoldingCompaniesClosedLoopRecycling > 0,
-            NoOfSubsidiariesClosedLoopRecycling = noOfSubsidiariesClosedLoopRecycling,
+            IsClosedLoopRecycling = (csoMember.NumberOfSubsidiaries > 0) && (csoMember.NumberOfHoldingCompaniesClosedLoopRecycling ?? 0) > 0,
+            NoOfSubsidiariesClosedLoopRecycling = 0,
             NumberOfSubsidiaries = csoMember.NumberOfSubsidiaries,
             NoOfSubsidiariesOnlineMarketplace = csoMember.NumberOfSubsidiariesOnlineMarketPlace
         };

--- a/src/EPR.RegulatorService.Frontend.Web/ViewModels/RegistrationSubmissions/CompliancePaymentDetailsViewModel.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewModels/RegistrationSubmissions/CompliancePaymentDetailsViewModel.cs
@@ -27,6 +27,10 @@ public class CompliancePaymentDetailsViewModel : PaymentDetailsViewModel
 
     public decimal SubsidiariesCompanyFee { get; set; }
 
+    public int SubsidiariesOnlineMarketPlaceCount { get; set; }
+
+    public decimal SubsidiariesOnlineMarketPlaceFee { get; set; }
+
     public int SubsidiariesClosedLoopRecyclingCount { get; set; }
 
     public decimal SubsidiariesClosedLoopRecyclingFee { get; set; }

--- a/src/EPR.RegulatorService.Frontend.Web/Views/Shared/Components/CompliancePaymentDetails/Default.cshtml
+++ b/src/EPR.RegulatorService.Frontend.Web/Views/Shared/Components/CompliancePaymentDetails/Default.cshtml
@@ -137,6 +137,21 @@
                             <payment-amount amount="@Model.SubsidiariesCompanyFee"></payment-amount>
                         </div>
 
+                        @if (Model.SubsidiariesOnlineMarketPlaceCount > 0)
+                        {
+                            <div class="govuk-summary-list__row" style="display: flex; justify-content: space-between;">
+                                <dd class="govuk-summary-list__value" style="width: 285px;">
+                                </dd>
+                                <dd class="govuk-summary-list__value" style="width: 310px;">
+                                    @Localizer[Model.SubsidiariesOnlineMarketPlaceCount == 1
+                                        ? "CompliancePaymentDetails.SubsidiaryOnlineMarketPlaceSingularDescription"
+                                        : "CompliancePaymentDetails.SubsidiaryOnlineMarketPlacePluralDescription"]
+                                </dd>
+                                <dd class="govuk-summary-list__value" style="width: 100px; text-align: right;">@Model.SubsidiariesOnlineMarketPlaceCount</dd>
+                                <payment-amount amount="@Model.SubsidiariesOnlineMarketPlaceFee"></payment-amount>
+                            </div>
+                        }
+
                         @if (Model.SubsidiariesClosedLoopRecyclingCount > 0)
                         {
                             <div class="govuk-summary-list__row" style="display: flex; justify-content: space-between;">

--- a/src/IntegrationTests/Builders/CsoMemberBuilder.cs
+++ b/src/IntegrationTests/Builders/CsoMemberBuilder.cs
@@ -1,0 +1,62 @@
+namespace IntegrationTests.Builders;
+
+public class CsoMemberBuilder
+{
+    private readonly string _memberId;
+    private string _memberType = "large";
+    private int _numberOfSubsidiaries;
+    private int _numberOfHoldingCompaniesClosedLoopRecycling;
+    private int _numberOfSubsidiariesClosedLoopRecycling;
+
+    private CsoMemberBuilder(string memberId)
+    {
+        _memberId = memberId;
+    }
+
+    public static CsoMemberBuilder Large(string memberId) => new(memberId);
+
+    public CsoMemberBuilder WithMemberType(string memberType)
+    {
+        _memberType = memberType;
+        return this;
+    }
+
+    public CsoMemberBuilder WithSubsidiaries(int count)
+    {
+        _numberOfSubsidiaries = count;
+        return this;
+    }
+
+    /// <summary>
+    /// Holding-company CLR count on the first CSO member drives how many large members receive the CLR flag.
+    /// </summary>
+    public CsoMemberBuilder WithHoldingCompanyClrCount(int count)
+    {
+        _numberOfHoldingCompaniesClosedLoopRecycling = count;
+        return this;
+    }
+
+    /// <summary>
+    /// Facade-only subsidiary CLR count; must not be forwarded to the payment API request.
+    /// </summary>
+    public CsoMemberBuilder WithSubsidiariesClosedLoopRecycling(int count)
+    {
+        _numberOfSubsidiariesClosedLoopRecycling = count;
+        return this;
+    }
+
+    internal object Build(int relevantYear, string submissionDate) => new
+    {
+        memberId = _memberId,
+        memberType = _memberType,
+        isOnlineMarketPlace = false,
+        isLateFeeApplicable = true,
+        numberOfHoldingCompaniesClosedLoopRecycling = _numberOfHoldingCompaniesClosedLoopRecycling,
+        NumberOfSubsidiariesClosedLoopRecycling = _numberOfSubsidiariesClosedLoopRecycling,
+        numberOfSubsidiaries = _numberOfSubsidiaries,
+        NumberOfSubsidiariesOnlineMarketPlace = 0,
+        relevantYear,
+        submittedDate = submissionDate,
+        submissionPeriodDescription = $"January to December {relevantYear}"
+    };
+}

--- a/src/IntegrationTests/Builders/RegistrationSubmissionDetailsBuilder.cs
+++ b/src/IntegrationTests/Builders/RegistrationSubmissionDetailsBuilder.cs
@@ -20,6 +20,7 @@ public class RegistrationSubmissionDetailsBuilder
     private int _csoMemberNumberOfSubsidiaries;
     private string _csoMemberType = "large";
     private string _applicationReferenceNumber = "REG-2025-001";
+    private List<CsoMemberBuilder>? _csoMembers;
 
     private RegistrationSubmissionDetailsBuilder(Guid submissionId)
     {
@@ -123,6 +124,16 @@ public class RegistrationSubmissionDetailsBuilder
         return this;
     }
 
+    public RegistrationSubmissionDetailsBuilder WithCsoMembers(params CsoMemberBuilder[] members)
+    {
+        _csoMembers = members.ToList();
+        _emptyCsoMembershipDetails = false;
+        _isComplianceScheme = true;
+        _organisationType = "compliance";
+        _registrationJourneyType = "CsoLargeProducer";
+        return this;
+    }
+
     public object Build() => new
     {
         submissionId = SubmissionId,
@@ -202,25 +213,38 @@ public class RegistrationSubmissionDetailsBuilder
         organisationSize = _organisationSize,
         isComplianceScheme = _isComplianceScheme,
         submissionPeriod = $"January to December {_relevantYear}",
-        csoMembershipDetails = _emptyCsoMembershipDetails
-            ? Array.Empty<object>()
-            : new object[]
-            {
-                new
-                {
-                    memberId = "100001",
-                    memberType = _csoMemberType,
-                    isOnlineMarketPlace = false,
-                    isLateFeeApplicable = true,
-                    numberOfHoldingCompaniesClosedLoopRecycling = _csoMemberNumberOfHoldingCompaniesClosedLoopRecycling,
-                    NumberOfSubsidiariesClosedLoopRecycling = _csoMemberNumberOfSubsidiariesClosedLoopRecycling,
-                    numberOfSubsidiaries = _csoMemberNumberOfSubsidiaries,
-                    NumberOfSubsidiariesOnlineMarketPlace = 0,
-                    relevantYear = _relevantYear,
-                    submittedDate = _submissionDate,
-                    submissionPeriodDescription = $"January to December {_relevantYear}"
-                }
-            },
+        csoMembershipDetails = BuildCsoMembershipDetails(),
         resubmissionFileId = (string?)null
     };
+
+    private object[] BuildCsoMembershipDetails()
+    {
+        if (_emptyCsoMembershipDetails)
+        {
+            return Array.Empty<object>();
+        }
+
+        if (_csoMembers is not null)
+        {
+            return _csoMembers.Select(m => m.Build(_relevantYear, _submissionDate)).ToArray<object>();
+        }
+
+        return
+        [
+            new
+            {
+                memberId = "100001",
+                memberType = _csoMemberType,
+                isOnlineMarketPlace = false,
+                isLateFeeApplicable = true,
+                numberOfHoldingCompaniesClosedLoopRecycling = _csoMemberNumberOfHoldingCompaniesClosedLoopRecycling,
+                NumberOfSubsidiariesClosedLoopRecycling = _csoMemberNumberOfSubsidiariesClosedLoopRecycling,
+                numberOfSubsidiaries = _csoMemberNumberOfSubsidiaries,
+                NumberOfSubsidiariesOnlineMarketPlace = 0,
+                relevantYear = _relevantYear,
+                submittedDate = _submissionDate,
+                submissionPeriodDescription = $"January to December {_relevantYear}"
+            }
+        ];
+    }
 }

--- a/src/IntegrationTests/Features/ClrPaymentScenarioIds.cs
+++ b/src/IntegrationTests/Features/ClrPaymentScenarioIds.cs
@@ -1,0 +1,22 @@
+namespace IntegrationTests.Features;
+
+internal static class ClrPaymentScenarioIds
+{
+    internal static readonly Guid Scenario01 = Guid.Parse("2a070c6a-7f3c-4ab2-8848-0cfe176d6ccf");
+    internal static readonly Guid Scenario02 = Guid.Parse("74bfb10b-6690-4ed0-b699-3e94d4136b10");
+    internal static readonly Guid Scenario03 = Guid.Parse("dd126010-46c8-4519-848b-fdd86142191a");
+    internal static readonly Guid Scenario04 = Guid.Parse("87061d73-bb95-4083-8d79-b0cdd05aa4be");
+    internal static readonly Guid Scenario05 = Guid.Parse("4233c8f6-9db6-4377-9ef2-b1e0dddbe2a8");
+    internal static readonly Guid Scenario06 = Guid.Parse("0c84b7eb-8bf6-4834-bd1f-91e98290cc2b");
+    internal static readonly Guid Scenario07 = Guid.Parse("b7e4a1c2-3d5f-6789-abcd-ef0123456789");
+    internal static readonly Guid Scenario08 = Guid.Parse("961983b6-dff7-4061-b621-df953a34f9c1");
+    internal static readonly Guid Scenario09 = Guid.Parse("c1a2b3d4-e5f6-7890-abcd-ef1234567890");
+    internal static readonly Guid Scenario10 = Guid.Parse("d2b3c4e5-f6a7-8901-bcde-f12345678901");
+    internal static readonly Guid Scenario11 = Guid.Parse("e3c4d5f6-a7b8-9012-cdef-123456789012");
+    internal static readonly Guid Scenario12 = Guid.Parse("f4d5e6a7-b8c9-0123-defa-234567890123");
+    internal static readonly Guid Scenario13 = Guid.Parse("a5e6f7b8-c9d0-1234-efab-345678901234");
+    internal static readonly Guid Scenario14 = Guid.Parse("b6f7a8c9-d0e1-2345-fabc-456789012345");
+    internal static readonly Guid Scenario15 = Guid.Parse("c7a8b9d0-e1f2-3456-abcd-567890123456");
+
+    internal static string AppRef(int scenario) => $"REG-SCENARIO-{scenario:D2}";
+}

--- a/src/IntegrationTests/Features/ClrPaymentScenarioTests.cs
+++ b/src/IntegrationTests/Features/ClrPaymentScenarioTests.cs
@@ -1,0 +1,878 @@
+namespace IntegrationTests.Features;
+
+using AwesomeAssertions;
+using AwesomeAssertions.Execution;
+using Builders;
+using Infrastructure;
+using PageModels;
+
+[Collection(SequentialCollection.Sequential)]
+public class ClrPaymentScenarioTests : IntegrationTestBase
+{
+    public override Task InitializeAsync()
+    {
+        base.InitializeAsync();
+        SetupUserAccountsMock();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    [Trait("Scenario", "01")]
+    public async Task DirectProducer_NoSubsidiaries_HcClrOff_SubClrOff_DisplaysNoClrLines_AndPostsProducerFeeRequest()
+    {
+        const int scenario = 1;
+        var submissionId = ClrPaymentScenarioIds.Scenario01;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .AsDirectLargeProducer()
+                .WithApplicationReferenceNumber(appRef));
+
+        FacadeServer.SetupProducerRegistrationFee(
+            ProducerPaymentResponseBuilder.Default()
+                .WithProducerRegistrationFee(284200)
+                .WithProducerLateRegistrationFee(77200)
+                .WithTotalFee(361400)
+                .WithOutstandingPayment(361400));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.PaymentDetails!.HasPaymentSection.Should().BeTrue();
+            page.ApplicationFee.Should().Be(2842.00m);
+            page.SubTotal.Should().Be(3614.00m);
+            page.TotalOutstanding.Should().Be(3614.00m);
+            AssertDirectProducerHasNoClrLines(page);
+        }
+
+        FacadeServer.ShouldHavePostedProducerRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            producerType = "large",
+            isClosedLoopRecycling = false,
+            noOfHoldingCompaniesClosedLoopRecycling = 0,
+            noOfSubsidiariesClosedLoopRecycling = 0,
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "02")]
+    public async Task DirectProducer_NoSubsidiaries_HcClrOn_SubClrOff_DisplaysHcClrLine_AndPostsProducerFeeRequest()
+    {
+        const int scenario = 2;
+        var submissionId = ClrPaymentScenarioIds.Scenario02;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int hcClrFeePence = 254800;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .AsDirectLargeProducer()
+                .WithApplicationReferenceNumber(appRef)
+                .WithProducerClosedLoopRecycling(0, 1));
+
+        FacadeServer.SetupProducerRegistrationFee(
+            ProducerPaymentResponseBuilder.Default()
+                .WithProducerRegistrationFee(284200)
+                .WithProducerLateRegistrationFee(77200)
+                .WithProducerClosedLoopRecyclingFee(hcClrFeePence)
+                .WithTotalFee(616200)
+                .WithOutstandingPayment(616200));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.SubTotal.Should().Be(6162.00m);
+            page.TotalOutstanding.Should().Be(6162.00m);
+            AssertDirectProducerHcClrLine(page, units: 1, amountPence: hcClrFeePence);
+            page.FindSubsidiaryClrLine().Should().BeNull();
+        }
+
+        FacadeServer.ShouldHavePostedProducerRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            producerType = "large",
+            isClosedLoopRecycling = true,
+            noOfHoldingCompaniesClosedLoopRecycling = 1,
+            noOfSubsidiariesClosedLoopRecycling = 0,
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "03")]
+    public async Task DirectProducer_3Subsidiaries_HcClrOff_SubClrOff_DisplaysSubsidiaryLineOnly_AndPostsProducerFeeRequest()
+    {
+        const int scenario = 3;
+        var submissionId = ClrPaymentScenarioIds.Scenario03;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int subsidiariesFeePence = 138000;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .AsDirectLargeProducer()
+                .WithApplicationReferenceNumber(appRef)
+                .WithProducerSubsidiaries(3));
+
+        FacadeServer.SetupProducerRegistrationFee(
+            ProducerPaymentResponseBuilder.Default()
+                .WithProducerRegistrationFee(284200)
+                .WithProducerLateRegistrationFee(77200)
+                .WithTotalFee(499400)
+                .WithOutstandingPayment(499400)
+                .WithSubsidiariesFeeBreakdown(subsidiariesFeePence, 0, 0));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.SubTotal.Should().Be(4994.00m);
+            AssertDirectProducerSubsidiaryCompaniesLine(page, units: 3, amountPence: subsidiariesFeePence);
+            AssertDirectProducerHasNoClrLines(page);
+        }
+
+        FacadeServer.ShouldHavePostedProducerRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            isClosedLoopRecycling = false,
+            noOfSubsidiariesClosedLoopRecycling = 0,
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "04")]
+    public async Task DirectProducer_3Subsidiaries_HcClrOn_SubClr3_DisplaysAllClrLines_AndPostsProducerFeeRequest()
+    {
+        const int scenario = 4;
+        var submissionId = ClrPaymentScenarioIds.Scenario04;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int hcClrFeePence = 254800;
+        const int subsidiariesFeePence = 647600;
+        const int subsidiaryClrFeePence = 509600;
+        const int netSubsidiaryFeePence = subsidiariesFeePence - subsidiaryClrFeePence;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .AsDirectLargeProducer()
+                .WithApplicationReferenceNumber(appRef)
+                .WithProducerSubsidiaries(3)
+                .WithProducerClosedLoopRecycling(3, 1));
+
+        FacadeServer.SetupProducerRegistrationFee(
+            ProducerPaymentResponseBuilder.Default()
+                .WithProducerRegistrationFee(284200)
+                .WithProducerLateRegistrationFee(77200)
+                .WithProducerClosedLoopRecyclingFee(hcClrFeePence)
+                .WithTotalFee(1773800)
+                .WithOutstandingPayment(1773800)
+                .WithSubsidiariesFeeBreakdown(subsidiariesFeePence, subsidiaryClrFeePence, 3));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.SubTotal.Should().Be(17738.00m);
+            AssertDirectProducerHcClrLine(page, units: 1, amountPence: hcClrFeePence);
+            AssertDirectProducerSubsidiaryCompaniesLine(page, units: 3, amountPence: netSubsidiaryFeePence);
+            AssertDirectProducerSubsidiaryClrLine(page, units: 3, amountPence: subsidiaryClrFeePence);
+        }
+
+        FacadeServer.ShouldHavePostedProducerRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            isClosedLoopRecycling = true,
+            noOfHoldingCompaniesClosedLoopRecycling = 1,
+            noOfSubsidiariesClosedLoopRecycling = 3,
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "05")]
+    public async Task Cso_1Member_HcClrOff_SubClrOff_DisplaysNoClrLines_AndPostsComplianceFeeRequest()
+    {
+        const int scenario = 5;
+        var submissionId = ClrPaymentScenarioIds.Scenario05;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .WithOrganisationType("compliance")
+                .WithRegistrationJourneyType("CsoLargeProducer")
+                .WithApplicationReferenceNumber(appRef));
+
+        FacadeServer.SetupComplianceSchemeRegistrationFee(
+            CompliancePaymentResponseBuilder.Default()
+                .WithComplianceSchemeRegistrationFee(284200)
+                .WithTotalFee(566300)
+                .WithMembers(ComplianceSchemeMemberFeeBuilder.Default()
+                    .WithMemberId("100001")
+                    .WithLateRegistrationFee(77200)
+                    .WithTotalMemberFee(566300)));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.ApplicationFee.Should().Be(2842.00m);
+            page.SubTotal.Should().Be(5663.00m);
+            AssertCsoHasNoClrLines(page);
+        }
+
+        FacadeServer.ShouldHavePostedComplianceSchemeRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            complianceSchemeMembers = new[]
+            {
+                new
+                {
+                    memberId = "100001",
+                    memberType = "large",
+                    isClosedLoopRecycling = false,
+                    noOfHoldingCompaniesClosedLoopRecycling = 0,
+                    noOfSubsidiariesClosedLoopRecycling = 0,
+                },
+            },
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "06")]
+    public async Task Cso_1Member_HcClrOn_SubClrOff_DisplaysHcClrLine_AndZerosSubClrInRequest()
+    {
+        const int scenario = 6;
+        var submissionId = ClrPaymentScenarioIds.Scenario06;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int hcClrFeePence = 254800;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .WithOrganisationType("compliance")
+                .WithRegistrationJourneyType("CsoLargeProducer")
+                .WithApplicationReferenceNumber(appRef)
+                .WithCsoMemberSubsidiaries(1)
+                .WithCsoMemberClosedLoopRecycling(8));
+
+        FacadeServer.SetupComplianceSchemeRegistrationFee(
+            CompliancePaymentResponseBuilder.Default()
+                .WithComplianceSchemeRegistrationFee(284200)
+                .WithTotalFee(821100)
+                .WithMembers(ComplianceSchemeMemberFeeBuilder.Default()
+                    .WithMemberId("100001")
+                    .WithLateRegistrationFee(77200)
+                    .WithMemberClosedLoopRecyclingFee(hcClrFeePence)
+                    .WithTotalMemberFee(821100)));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.SubTotal.Should().Be(8211.00m);
+            AssertCsoHcClrLine(page, units: 1, amountPence: hcClrFeePence);
+            page.FindSubsidiaryClrLine().Should().BeNull();
+        }
+
+        FacadeServer.ShouldHavePostedComplianceSchemeRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            complianceSchemeMembers = new[]
+            {
+                new
+                {
+                    memberId = "100001",
+                    memberType = "large",
+                    isClosedLoopRecycling = true,
+                    noOfHoldingCompaniesClosedLoopRecycling = 1,
+                    noOfSubsidiariesClosedLoopRecycling = 0,
+                },
+            },
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "07")]
+    public async Task Cso_3Members_3SubsEach_HcClrOff_SubClrOff_DisplaysAggregatedSubsidiaries_AndPostsComplianceFeeRequest()
+    {
+        const int scenario = 7;
+        var submissionId = ClrPaymentScenarioIds.Scenario07;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int subsidiariesFeePerMemberPence = 138000;
+        const int memberRegistrationFeePence = 165800;
+        const int totalFeePence = 284200 + (memberRegistrationFeePence + subsidiariesFeePerMemberPence) * 3;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .WithApplicationReferenceNumber(appRef)
+                .WithCsoMembers(
+                    CsoMemberBuilder.Large("100001").WithSubsidiaries(3),
+                    CsoMemberBuilder.Large("100002").WithSubsidiaries(3),
+                    CsoMemberBuilder.Large("100003").WithSubsidiaries(3)));
+
+        FacadeServer.SetupComplianceSchemeRegistrationFee(
+            CompliancePaymentResponseBuilder.Default()
+                .WithComplianceSchemeRegistrationFee(284200)
+                .WithTotalFee(totalFeePence)
+                .WithMembers(
+                    BuildCsoMemberWithSubsidiaries("100001", memberRegistrationFeePence, subsidiariesFeePerMemberPence),
+                    BuildCsoMemberWithSubsidiaries("100002", memberRegistrationFeePence, subsidiariesFeePerMemberPence),
+                    BuildCsoMemberWithSubsidiaries("100003", memberRegistrationFeePence, subsidiariesFeePerMemberPence)));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.SubTotal.Should().Be(totalFeePence / 100m);
+            AssertCsoLargeProducersLine(page, units: 3);
+            AssertCsoSubsidiaryCompaniesLine(page, units: 9, amountPence: subsidiariesFeePerMemberPence * 3);
+            AssertCsoHasNoClrLines(page);
+        }
+
+        FacadeServer.ShouldHavePostedComplianceSchemeRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            complianceSchemeMembers = new[]
+            {
+                new { memberId = "100001", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 0 },
+                new { memberId = "100002", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 0 },
+                new { memberId = "100003", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 0 },
+            },
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "08")]
+    [Trait("Category", "AMCR-291")]
+    public async Task Cso_3Members_3SubsEach_HcClr3_SubClr3_DisplaysAggregatedClrFees_AndZerosSubClrInRequest()
+    {
+        const int scenario = 8;
+        var submissionId = ClrPaymentScenarioIds.Scenario08;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int hcClrFeePence = 254800;
+        const int subsidiariesFeePence = 647600;
+        const int subsidiaryClrFeePence = 509600;
+        const int netSubsidiaryFeePence = subsidiariesFeePence - subsidiaryClrFeePence;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .WithApplicationReferenceNumber(appRef)
+                .WithCsoMembers(
+                    CsoMemberBuilder.Large("100001")
+                        .WithHoldingCompanyClrCount(3)
+                        .WithSubsidiaries(3)
+                        .WithSubsidiariesClosedLoopRecycling(3),
+                    CsoMemberBuilder.Large("100002")
+                        .WithSubsidiaries(3)
+                        .WithSubsidiariesClosedLoopRecycling(3),
+                    CsoMemberBuilder.Large("100003")
+                        .WithSubsidiaries(3)
+                        .WithSubsidiariesClosedLoopRecycling(3)));
+
+        FacadeServer.SetupComplianceSchemeRegistrationFee(
+            CompliancePaymentResponseBuilder.Default()
+                .WithComplianceSchemeRegistrationFee(284200)
+                .WithTotalFee(5000000)
+                .WithMembers(
+                    BuildCsoMemberWithSubsidiaryClr("100001", hcClrFeePence, subsidiariesFeePence, subsidiaryClrFeePence, 3),
+                    BuildCsoMemberWithSubsidiaryClr("100002", hcClrFeePence, subsidiariesFeePence, subsidiaryClrFeePence, 3),
+                    BuildCsoMemberWithSubsidiaryClr("100003", hcClrFeePence, subsidiariesFeePence, subsidiaryClrFeePence, 3)));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            AssertCsoHcClrLine(page, units: 3, amountPence: hcClrFeePence * 3);
+            AssertCsoSubsidiaryCompaniesLine(page, units: 9, amountPence: netSubsidiaryFeePence * 3);
+            AssertCsoSubsidiaryClrLine(page, units: 9, amountPence: subsidiaryClrFeePence * 3);
+        }
+
+        FacadeServer.ShouldHavePostedComplianceSchemeRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            complianceSchemeMembers = new[]
+            {
+                new { memberId = "100001", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1, noOfSubsidiariesClosedLoopRecycling = 0 },
+                new { memberId = "100002", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1, noOfSubsidiariesClosedLoopRecycling = 0 },
+                new { memberId = "100003", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1, noOfSubsidiariesClosedLoopRecycling = 0 },
+            },
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "09")]
+    public async Task DirectProducer_3Subsidiaries_HcClrOn_SubClrOff_DisplaysHcClrAndFullSubsidiaryFee_AndPostsProducerFeeRequest()
+    {
+        const int scenario = 9;
+        var submissionId = ClrPaymentScenarioIds.Scenario09;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int hcClrFeePence = 254800;
+        const int subsidiariesFeePence = 647600;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .AsDirectLargeProducer()
+                .WithApplicationReferenceNumber(appRef)
+                .WithProducerSubsidiaries(3)
+                .WithProducerClosedLoopRecycling(0, 1));
+
+        FacadeServer.SetupProducerRegistrationFee(
+            ProducerPaymentResponseBuilder.Default()
+                .WithProducerRegistrationFee(284200)
+                .WithProducerLateRegistrationFee(77200)
+                .WithProducerClosedLoopRecyclingFee(hcClrFeePence)
+                .WithTotalFee(1263800)
+                .WithOutstandingPayment(1263800)
+                .WithSubsidiariesFeeBreakdown(subsidiariesFeePence, 0, 0));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.SubTotal.Should().Be(12638.00m);
+            AssertDirectProducerHcClrLine(page, units: 1, amountPence: hcClrFeePence);
+            AssertDirectProducerSubsidiaryCompaniesLine(page, units: 3, amountPence: subsidiariesFeePence);
+            page.FindSubsidiaryClrLine().Should().BeNull();
+        }
+
+        FacadeServer.ShouldHavePostedProducerRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            isClosedLoopRecycling = true,
+            noOfHoldingCompaniesClosedLoopRecycling = 1,
+            noOfSubsidiariesClosedLoopRecycling = 0,
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "10")]
+    public async Task DirectProducer_3Subsidiaries_HcClrOff_SubClr2_DisplaysPartialSubClrOnly_AndPostsProducerFeeRequest()
+    {
+        const int scenario = 10;
+        var submissionId = ClrPaymentScenarioIds.Scenario10;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int subsidiariesFeePence = 647600;
+        const int subsidiaryClrFeePence = 339700;
+        const int netSubsidiaryFeePence = subsidiariesFeePence - subsidiaryClrFeePence;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .AsDirectLargeProducer()
+                .WithApplicationReferenceNumber(appRef)
+                .WithProducerSubsidiaries(3)
+                .WithProducerClosedLoopRecycling(2, 0));
+
+        FacadeServer.SetupProducerRegistrationFee(
+            ProducerPaymentResponseBuilder.Default()
+                .WithProducerRegistrationFee(284200)
+                .WithProducerLateRegistrationFee(77200)
+                .WithTotalFee(1271000)
+                .WithOutstandingPayment(1271000)
+                .WithSubsidiariesFeeBreakdown(subsidiariesFeePence, subsidiaryClrFeePence, 2));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.SubTotal.Should().Be(12710.00m);
+            page.FindDirectProducerHoldingCompanyClrLine().Should().BeNull();
+            AssertDirectProducerSubsidiaryCompaniesLine(page, units: 3, amountPence: netSubsidiaryFeePence);
+            AssertDirectProducerSubsidiaryClrLine(page, units: 2, amountPence: subsidiaryClrFeePence);
+        }
+
+        FacadeServer.ShouldHavePostedProducerRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            isClosedLoopRecycling = false,
+            noOfHoldingCompaniesClosedLoopRecycling = 0,
+            noOfSubsidiariesClosedLoopRecycling = 2,
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "11")]
+    public async Task DirectProducer_3Subsidiaries_HcClrOn_SubClr2_DisplaysBothClrTypes_AndPostsProducerFeeRequest()
+    {
+        const int scenario = 11;
+        var submissionId = ClrPaymentScenarioIds.Scenario11;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int hcClrFeePence = 254800;
+        const int subsidiariesFeePence = 647600;
+        const int subsidiaryClrFeePence = 339700;
+        const int netSubsidiaryFeePence = subsidiariesFeePence - subsidiaryClrFeePence;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .AsDirectLargeProducer()
+                .WithApplicationReferenceNumber(appRef)
+                .WithProducerSubsidiaries(3)
+                .WithProducerClosedLoopRecycling(2, 1));
+
+        FacadeServer.SetupProducerRegistrationFee(
+            ProducerPaymentResponseBuilder.Default()
+                .WithProducerRegistrationFee(284200)
+                .WithProducerLateRegistrationFee(77200)
+                .WithProducerClosedLoopRecyclingFee(hcClrFeePence)
+                .WithTotalFee(1603500)
+                .WithOutstandingPayment(1603500)
+                .WithSubsidiariesFeeBreakdown(subsidiariesFeePence, subsidiaryClrFeePence, 2));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.SubTotal.Should().Be(16035.00m);
+            AssertDirectProducerHcClrLine(page, units: 1, amountPence: hcClrFeePence);
+            AssertDirectProducerSubsidiaryCompaniesLine(page, units: 3, amountPence: netSubsidiaryFeePence);
+            AssertDirectProducerSubsidiaryClrLine(page, units: 2, amountPence: subsidiaryClrFeePence);
+        }
+
+        FacadeServer.ShouldHavePostedProducerRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            isClosedLoopRecycling = true,
+            noOfHoldingCompaniesClosedLoopRecycling = 1,
+            noOfSubsidiariesClosedLoopRecycling = 2,
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "12")]
+    public async Task Cso_3LargeMembers_HcClr2_SubClrOff_FlagsFirstTwoMembersOnly_AndDisplaysHcClrLine()
+    {
+        const int scenario = 12;
+        var submissionId = ClrPaymentScenarioIds.Scenario12;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int hcClrFeePence = 254800;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .WithApplicationReferenceNumber(appRef)
+                .WithCsoMembers(
+                    CsoMemberBuilder.Large("100001").WithHoldingCompanyClrCount(2),
+                    CsoMemberBuilder.Large("100002"),
+                    CsoMemberBuilder.Large("100003")));
+
+        FacadeServer.SetupComplianceSchemeRegistrationFee(
+            CompliancePaymentResponseBuilder.Default()
+                .WithComplianceSchemeRegistrationFee(284200)
+                .WithTotalFee(1200000)
+                .WithMembers(
+                    BuildCsoMemberWithHcClr("100001", hcClrFeePence),
+                    BuildCsoMemberWithHcClr("100002", hcClrFeePence),
+                    ComplianceSchemeMemberFeeBuilder.Default()
+                        .WithMemberId("100003")
+                        .WithTotalMemberFee(165800)));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.SubTotal.Should().Be(12000.00m);
+            AssertCsoHcClrLine(page, units: 2, amountPence: hcClrFeePence * 2);
+            page.FindSubsidiaryClrLine().Should().BeNull();
+        }
+
+        FacadeServer.ShouldHavePostedComplianceSchemeRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            complianceSchemeMembers = new[]
+            {
+                new { memberId = "100001", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1 },
+                new { memberId = "100002", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1 },
+                new { memberId = "100003", isClosedLoopRecycling = false, noOfHoldingCompaniesClosedLoopRecycling = 0 },
+            },
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "13")]
+    public async Task Cso_2Large1Small_HcClr2_SubClrOff_ExcludesSmallMemberFromHcClr_AndDisplaysHcClrLine()
+    {
+        const int scenario = 13;
+        var submissionId = ClrPaymentScenarioIds.Scenario13;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int hcClrFeePence = 254800;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .WithApplicationReferenceNumber(appRef)
+                .WithCsoMembers(
+                    CsoMemberBuilder.Large("100001").WithHoldingCompanyClrCount(2),
+                    CsoMemberBuilder.Large("100002"),
+                    CsoMemberBuilder.Large("100003").WithMemberType("small")));
+
+        FacadeServer.SetupComplianceSchemeRegistrationFee(
+            CompliancePaymentResponseBuilder.Default()
+                .WithComplianceSchemeRegistrationFee(284200)
+                .WithTotalFee(900000)
+                .WithMembers(
+                    BuildCsoMemberWithHcClr("100001", hcClrFeePence),
+                    BuildCsoMemberWithHcClr("100002", hcClrFeePence),
+                    ComplianceSchemeMemberFeeBuilder.Default()
+                        .WithMemberId("100003")
+                        .WithMemberType("small")
+                        .WithMemberRegistrationFee(48000)
+                        .WithTotalMemberFee(48000)));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.SubTotal.Should().Be(9000.00m);
+            AssertCsoHcClrLine(page, units: 2, amountPence: hcClrFeePence * 2);
+            page.FindSubsidiaryClrLine().Should().BeNull();
+        }
+
+        FacadeServer.ShouldHavePostedComplianceSchemeRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            complianceSchemeMembers = new[]
+            {
+                new { memberId = "100001", memberType = "large", isClosedLoopRecycling = true },
+                new { memberId = "100002", memberType = "large", isClosedLoopRecycling = true },
+                new { memberId = "100003", memberType = "small", isClosedLoopRecycling = false },
+            },
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "14")]
+    public async Task Cso_3Members_3SubsEach_HcClrOff_SubClrMixed_DisplaysAggregatedPartialSubClr_AndZerosSubClrInRequest()
+    {
+        const int scenario = 14;
+        var submissionId = ClrPaymentScenarioIds.Scenario14;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int subsidiariesFeePence = 647600;
+        const int memberOneClrFeePence = 509600;
+        const int memberTwoClrFeePence = 169900;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .WithApplicationReferenceNumber(appRef)
+                .WithCsoMembers(
+                    CsoMemberBuilder.Large("100001").WithSubsidiaries(3).WithSubsidiariesClosedLoopRecycling(3),
+                    CsoMemberBuilder.Large("100002").WithSubsidiaries(3).WithSubsidiariesClosedLoopRecycling(1),
+                    CsoMemberBuilder.Large("100003").WithSubsidiaries(3).WithSubsidiariesClosedLoopRecycling(0)));
+
+        FacadeServer.SetupComplianceSchemeRegistrationFee(
+            CompliancePaymentResponseBuilder.Default()
+                .WithComplianceSchemeRegistrationFee(284200)
+                .WithTotalFee(4000000)
+                .WithMembers(
+                    BuildCsoMemberWithSubsidiaryClrBreakdown("100001", subsidiariesFeePence, memberOneClrFeePence, 3),
+                    BuildCsoMemberWithSubsidiaryClrBreakdown("100002", subsidiariesFeePence, memberTwoClrFeePence, 1),
+                    BuildCsoMemberWithSubsidiaries("100003", 165800, subsidiariesFeePence)));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.FindCsoHoldingCompanyClrLine().Should().BeNull();
+            AssertCsoSubsidiaryCompaniesLine(
+                page,
+                units: 9,
+                amountPence: (subsidiariesFeePence - memberOneClrFeePence)
+                             + (subsidiariesFeePence - memberTwoClrFeePence)
+                             + subsidiariesFeePence);
+            AssertCsoSubsidiaryClrLine(page, units: 4, amountPence: memberOneClrFeePence + memberTwoClrFeePence);
+        }
+
+        FacadeServer.ShouldHavePostedComplianceSchemeRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            complianceSchemeMembers = new[]
+            {
+                new { memberId = "100001", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 0 },
+                new { memberId = "100002", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 0 },
+                new { memberId = "100003", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 0 },
+            },
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "15")]
+    public async Task Cso_3Members_3SubsEach_HcClr2_SubClrMixed_DisplaysBothClrTypes_AndZerosSubClrInRequest()
+    {
+        const int scenario = 15;
+        var submissionId = ClrPaymentScenarioIds.Scenario15;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int hcClrFeePence = 254800;
+        const int subsidiariesFeePence = 647600;
+        const int memberOneSubClrFeePence = 509600;
+        const int memberTwoSubClrFeePence = 169900;
+        const int netSubsidiaryFeePence =
+            (subsidiariesFeePence - memberOneSubClrFeePence)
+            + (subsidiariesFeePence - memberTwoSubClrFeePence)
+            + subsidiariesFeePence;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .WithApplicationReferenceNumber(appRef)
+                .WithCsoMembers(
+                    CsoMemberBuilder.Large("100001")
+                        .WithHoldingCompanyClrCount(2)
+                        .WithSubsidiaries(3)
+                        .WithSubsidiariesClosedLoopRecycling(3),
+                    CsoMemberBuilder.Large("100002")
+                        .WithSubsidiaries(3)
+                        .WithSubsidiariesClosedLoopRecycling(1),
+                    CsoMemberBuilder.Large("100003").WithSubsidiaries(3)));
+
+        FacadeServer.SetupComplianceSchemeRegistrationFee(
+            CompliancePaymentResponseBuilder.Default()
+                .WithComplianceSchemeRegistrationFee(284200)
+                .WithTotalFee(6000000)
+                .WithMembers(
+                    BuildCsoMemberWithHcAndSubsidiaryClr("100001", hcClrFeePence, subsidiariesFeePence, memberOneSubClrFeePence, 3),
+                    BuildCsoMemberWithHcAndSubsidiaryClr("100002", hcClrFeePence, subsidiariesFeePence, memberTwoSubClrFeePence, 1),
+                    BuildCsoMemberWithSubsidiaries("100003", 165800, subsidiariesFeePence)));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            AssertCsoHcClrLine(page, units: 2, amountPence: hcClrFeePence * 2);
+            AssertCsoSubsidiaryClrLine(page, units: 4, amountPence: memberOneSubClrFeePence + memberTwoSubClrFeePence);
+            AssertCsoSubsidiaryCompaniesLine(page, units: 9, amountPence: netSubsidiaryFeePence);
+        }
+
+        FacadeServer.ShouldHavePostedComplianceSchemeRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            complianceSchemeMembers = new[]
+            {
+                new { memberId = "100001", isClosedLoopRecycling = true, noOfSubsidiariesClosedLoopRecycling = 0 },
+                new { memberId = "100002", isClosedLoopRecycling = true, noOfSubsidiariesClosedLoopRecycling = 0 },
+                new { memberId = "100003", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 0 },
+            },
+        });
+    }
+
+    private async Task<ManageRegistrationSubmissionDetailsPageModel> LoadDetailsPage(Guid submissionId) =>
+        await GetAsPageModel<ManageRegistrationSubmissionDetailsPageModel>(
+            $"/regulators/registration-submission-details/{submissionId}");
+
+    private static void AssertDirectProducerHasNoClrLines(ManageRegistrationSubmissionDetailsPageModel page)
+    {
+        page.FindDirectProducerHoldingCompanyClrLine().Should().BeNull();
+        page.FindSubsidiaryClrLine().Should().BeNull();
+    }
+
+    private static void AssertCsoHasNoClrLines(ManageRegistrationSubmissionDetailsPageModel page)
+    {
+        page.FindCsoHoldingCompanyClrLine().Should().BeNull();
+        page.FindSubsidiaryClrLine().Should().BeNull();
+    }
+
+    private static void AssertDirectProducerHcClrLine(
+        ManageRegistrationSubmissionDetailsPageModel page,
+        int units,
+        int amountPence)
+    {
+        var line = page.FindDirectProducerHoldingCompanyClrLine();
+        line.Should().NotBeNull();
+        line!.Units.Should().Be(units);
+        line.Amount.Should().Be(amountPence / 100m);
+    }
+
+    private static void AssertCsoHcClrLine(
+        ManageRegistrationSubmissionDetailsPageModel page,
+        int units,
+        int amountPence)
+    {
+        var line = page.FindCsoHoldingCompanyClrLine();
+        line.Should().NotBeNull();
+        line!.Units.Should().Be(units);
+        line.Amount.Should().Be(amountPence / 100m);
+    }
+
+    private static void AssertDirectProducerSubsidiaryCompaniesLine(
+        ManageRegistrationSubmissionDetailsPageModel page,
+        int units,
+        int amountPence)
+    {
+        var line = page.FindSubsidiaryCompaniesLine();
+        line.Should().NotBeNull();
+        line!.Units.Should().Be(units);
+        line.Amount.Should().Be(amountPence / 100m);
+    }
+
+    private static void AssertCsoSubsidiaryCompaniesLine(
+        ManageRegistrationSubmissionDetailsPageModel page,
+        int units,
+        int amountPence)
+    {
+        AssertDirectProducerSubsidiaryCompaniesLine(page, units, amountPence);
+    }
+
+    private static void AssertDirectProducerSubsidiaryClrLine(
+        ManageRegistrationSubmissionDetailsPageModel page,
+        int units,
+        int amountPence)
+    {
+        var line = page.FindSubsidiaryClrLine();
+        line.Should().NotBeNull();
+        line!.Units.Should().Be(units);
+        line.Amount.Should().Be(amountPence / 100m);
+    }
+
+    private static void AssertCsoSubsidiaryClrLine(
+        ManageRegistrationSubmissionDetailsPageModel page,
+        int units,
+        int amountPence) =>
+        AssertDirectProducerSubsidiaryClrLine(page, units, amountPence);
+
+    private static void AssertCsoLargeProducersLine(ManageRegistrationSubmissionDetailsPageModel page, int units)
+    {
+        var line = page.FindLargeProducersLine();
+        line.Should().NotBeNull();
+        line!.Units.Should().Be(units);
+    }
+
+    private static ComplianceSchemeMemberFeeBuilder BuildCsoMemberWithSubsidiaries(
+        string memberId,
+        int memberRegistrationFeePence,
+        int subsidiariesFeePence) =>
+        ComplianceSchemeMemberFeeBuilder.Default()
+            .WithMemberId(memberId)
+            .WithMemberRegistrationFee(memberRegistrationFeePence)
+            .WithSubsidiariesFee(subsidiariesFeePence)
+            .WithTotalMemberFee(memberRegistrationFeePence + subsidiariesFeePence);
+
+    private static ComplianceSchemeMemberFeeBuilder BuildCsoMemberWithHcClr(string memberId, int hcClrFeePence) =>
+        ComplianceSchemeMemberFeeBuilder.Default()
+            .WithMemberId(memberId)
+            .WithMemberClosedLoopRecyclingFee(hcClrFeePence)
+            .WithTotalMemberFee(165800 + hcClrFeePence);
+
+    private static ComplianceSchemeMemberFeeBuilder BuildCsoMemberWithSubsidiaryClrBreakdown(
+        string memberId,
+        int subsidiariesFeePence,
+        int subsidiaryClrFeePence,
+        int subsidiaryClrCount) =>
+        ComplianceSchemeMemberFeeBuilder.Default()
+            .WithMemberId(memberId)
+            .WithMemberRegistrationFee(165800)
+            .WithTotalMemberFee(165800 + subsidiariesFeePence)
+            .WithSubsidiariesFeeBreakdown(subsidiariesFeePence, subsidiaryClrFeePence, subsidiaryClrCount);
+
+    private static ComplianceSchemeMemberFeeBuilder BuildCsoMemberWithSubsidiaryClr(
+        string memberId,
+        int hcClrFeePence,
+        int subsidiariesFeePence,
+        int subsidiaryClrFeePence,
+        int subsidiaryClrCount) =>
+        ComplianceSchemeMemberFeeBuilder.Default()
+            .WithMemberId(memberId)
+            .WithMemberRegistrationFee(165800)
+            .WithMemberClosedLoopRecyclingFee(hcClrFeePence)
+            .WithTotalMemberFee(165800 + hcClrFeePence + subsidiariesFeePence)
+            .WithSubsidiariesFeeBreakdown(subsidiariesFeePence, subsidiaryClrFeePence, subsidiaryClrCount);
+
+    private static ComplianceSchemeMemberFeeBuilder BuildCsoMemberWithHcAndSubsidiaryClr(
+        string memberId,
+        int hcClrFeePence,
+        int subsidiariesFeePence,
+        int subsidiaryClrFeePence,
+        int subsidiaryClrCount) =>
+        BuildCsoMemberWithSubsidiaryClr(memberId, hcClrFeePence, subsidiariesFeePence, subsidiaryClrFeePence, subsidiaryClrCount);
+}

--- a/src/IntegrationTests/Features/RegistrationSubmissionDetailsTests.cs
+++ b/src/IntegrationTests/Features/RegistrationSubmissionDetailsTests.cs
@@ -96,6 +96,7 @@ public class RegistrationSubmissionDetailsTests : IntegrationTestBase
                 .WithOrganisationType("compliance")
                 .WithRegistrationJourneyType("CsoLargeProducer")
                 .WithApplicationReferenceNumber(appRef)
+                .WithCsoMemberSubsidiaries(1)
                 .WithCsoMemberClosedLoopRecycling(8));
 
         SetupPaymentFacadeMockComplianceSchemeRegistrationFee(
@@ -122,7 +123,7 @@ public class RegistrationSubmissionDetailsTests : IntegrationTestBase
                         memberType = "large",
                         isClosedLoopRecycling = true,
                         noOfHoldingCompaniesClosedLoopRecycling = 1,
-                        noOfSubsidiariesClosedLoopRecycling = 8,
+                        noOfSubsidiariesClosedLoopRecycling = 0,
                     },
                 },
             }));
@@ -174,7 +175,6 @@ public class RegistrationSubmissionDetailsTests : IntegrationTestBase
         const int subsidiariesFeePence = 647600;
         const int subsidiaryClrFeePence = 509600;
         const int subsidiaryClrCount = 2;
-        const int netSubsidiaryFeePence = subsidiariesFeePence - subsidiaryClrFeePence;
 
         SetupFacadeMockRegistrationSubmissionDetails(
             RegistrationSubmissionDetailsBuilder.Default(submissionId)
@@ -207,7 +207,7 @@ public class RegistrationSubmissionDetailsTests : IntegrationTestBase
             var subsidiaryCompanies = detailsPage.FindPaymentLineItem("Subsidiary companies");
             subsidiaryCompanies.Should().NotBeNull();
             subsidiaryCompanies!.Units.Should().Be(subsidiaryClrCount);
-            subsidiaryCompanies.Amount.Should().Be(netSubsidiaryFeePence / 100m);
+            subsidiaryCompanies.Amount.Should().Be(subsidiariesFeePence / 100m);
 
             var subsidiaryClr = detailsPage.FindPaymentLineItem("Subsidiaries closed loop packaging waste");
             subsidiaryClr.Should().NotBeNull();

--- a/src/IntegrationTests/Features/RegistrationSubmissionDetailsTests.cs
+++ b/src/IntegrationTests/Features/RegistrationSubmissionDetailsTests.cs
@@ -1,16 +1,10 @@
 namespace IntegrationTests.Features;
 
-using System.Text.Json;
 using AwesomeAssertions;
 using AwesomeAssertions.Execution;
 using Builders;
 using Infrastructure;
 using PageModels;
-using WireMock.AwesomeAssertions;
-using WireMock.Matchers;
-using WireMock.RequestBuilders;
-using WireMock.ResponseBuilders;
-using WireMock.Server;
 
 [Collection(SequentialCollection.Sequential)]
 public class RegistrationSubmissionDetailsTests : IntegrationTestBase
@@ -29,7 +23,7 @@ public class RegistrationSubmissionDetailsTests : IntegrationTestBase
         // Arrange
         var submissionId = Guid.Parse("0163A629-7780-445F-B00E-1898546BDF0C");
 
-        SetupFacadeMockRegistrationSubmissionDetails(
+        FacadeServer.SetupRegistrationSubmissionDetails(
             RegistrationSubmissionDetailsBuilder.Default(submissionId)
                 .WithOrganisationName("Compliance Scheme Ltd")
                 .WithOrganisationType("compliance")
@@ -54,13 +48,13 @@ public class RegistrationSubmissionDetailsTests : IntegrationTestBase
         // Arrange
         var submissionId = Guid.Parse("1b2c3d4e-5f6a-7b8c-9d0e-1f2a3b4c5d6e");
 
-        SetupFacadeMockRegistrationSubmissionDetails(
+        FacadeServer.SetupRegistrationSubmissionDetails(
             RegistrationSubmissionDetailsBuilder.Default(submissionId)
                 .WithOrganisationName("CSO Large Producer Ltd")
                 .WithOrganisationType("compliance")
                 .WithRelevantYear(2025));
 
-        SetupPaymentFacadeMockComplianceSchemeRegistrationFee(
+        FacadeServer.SetupComplianceSchemeRegistrationFee(
             CompliancePaymentResponseBuilder.Default()
                 .WithComplianceSchemeRegistrationFee(284200)
                 .WithTotalFee(588500)
@@ -83,216 +77,4 @@ public class RegistrationSubmissionDetailsTests : IntegrationTestBase
             detailsPage.TotalOutstanding.Should().Be(5385.00m);
         }
     }
-
-    [Fact]
-    public async Task RegistrationSubmissionDetailsPage_PostsComplianceSchemeRegistrationFeeWithClosedLoopRecyclingFields()
-    {
-        // Arrange
-        var submissionId = Guid.NewGuid();
-        const string appRef = "REG-INT-CSO-CL-001";
-
-        SetupFacadeMockRegistrationSubmissionDetails(
-            RegistrationSubmissionDetailsBuilder.Default(submissionId)
-                .WithOrganisationType("compliance")
-                .WithRegistrationJourneyType("CsoLargeProducer")
-                .WithApplicationReferenceNumber(appRef)
-                .WithCsoMemberSubsidiaries(1)
-                .WithCsoMemberClosedLoopRecycling(8));
-
-        SetupPaymentFacadeMockComplianceSchemeRegistrationFee(
-            CompliancePaymentResponseBuilder.Default()
-                .WithComplianceSchemeRegistrationFee(100000)
-                .WithTotalFee(100000));
-
-        // Act
-        await GetAsPageModel<ManageRegistrationSubmissionDetailsPageModel>(
-            $"/regulators/registration-submission-details/{submissionId}");
-
-        // Assert
-        var assertions = FacadeServer.Should().HaveReceivedACall();
-        assertions
-            .UsingPost().And
-            .AtPath("/compliance-scheme/registration-fee").And
-            .WithBodyAsJson(new JsonPartialMatcher(new
-            {
-                applicationReferenceNumber = appRef,
-                complianceSchemeMembers = new[]
-                {
-                    new
-                    {
-                        memberType = "large",
-                        isClosedLoopRecycling = true,
-                        noOfHoldingCompaniesClosedLoopRecycling = 1,
-                        noOfSubsidiariesClosedLoopRecycling = 0,
-                    },
-                },
-            }));
-    }
-
-    [Fact]
-    public async Task RegistrationSubmissionDetailsPage_PostsProducerRegistrationFeeWithClosedLoopRecyclingFields()
-    {
-        // Arrange
-        var submissionId = Guid.NewGuid();
-        const string appRef = "REG-INT-DIRECT-CL-001";
-
-        SetupFacadeMockRegistrationSubmissionDetails(
-            RegistrationSubmissionDetailsBuilder.Default(submissionId)
-                .AsDirectLargeProducer()
-                .WithApplicationReferenceNumber(appRef)
-                .WithProducerClosedLoopRecycling(5));
-
-        SetupPaymentFacadeMockProducerRegistrationFee(
-            ProducerPaymentResponseBuilder.Default()
-                .WithProducerRegistrationFee(100000)
-                .WithTotalFee(100000)
-                .WithOutstandingPayment(100000));
-
-        // Act
-        await GetAsPageModel<ManageRegistrationSubmissionDetailsPageModel>(
-            $"/regulators/registration-submission-details/{submissionId}");
-
-        // Assert
-        var assertions = FacadeServer.Should().HaveReceivedACall();
-        assertions
-            .UsingPost().And
-            .AtPath("/producer/registration-fee").And
-            .WithBodyAsJson(new JsonPartialMatcher(new
-            {
-                applicationReferenceNumber = appRef,
-                producerType = "large",
-                noOfHoldingCompaniesClosedLoopRecycling = 1,
-                isClosedLoopRecycling = true,
-                noOfSubsidiariesClosedLoopRecycling = 5,
-            }));
-    }
-
-    [Fact]
-    public async Task RegistrationSubmissionDetailsPage_ShowsComplianceSchemeSubsidiaryClrPaymentLineItems()
-    {
-        // Arrange
-        var submissionId = Guid.NewGuid();
-        const int subsidiariesFeePence = 647600;
-        const int subsidiaryClrFeePence = 509600;
-        const int subsidiaryClrCount = 2;
-        const int netSubsidiaryFeePence = subsidiariesFeePence - subsidiaryClrFeePence;
-
-        SetupFacadeMockRegistrationSubmissionDetails(
-            RegistrationSubmissionDetailsBuilder.Default(submissionId)
-                .WithOrganisationType("compliance")
-                .WithRegistrationJourneyType("CsoLargeProducer")
-                .WithCsoMemberSubsidiaries(subsidiaryClrCount));
-
-        SetupPaymentFacadeMockComplianceSchemeRegistrationFee(
-            CompliancePaymentResponseBuilder.Default()
-                .WithComplianceSchemeRegistrationFee(284200)
-                .WithTotalFee(1174800)
-                .WithMembers(ComplianceSchemeMemberFeeBuilder.Default()
-                    .WithLateRegistrationFee(77200)
-                    .WithTotalMemberFee(890600)
-                    .WithSubsidiariesFeeBreakdown(
-                        subsidiariesFeePence,
-                        subsidiaryClrFeePence,
-                        subsidiaryClrCount)));
-
-        // Act
-        var detailsPage = await GetAsPageModel<ManageRegistrationSubmissionDetailsPageModel>(
-            $"/regulators/registration-submission-details/{submissionId}");
-
-        // Assert
-        using (new AssertionScope())
-        {
-            detailsPage.ApplicationFee.Should().Be(2842.00m);
-            detailsPage.SubTotal.Should().Be(11748.00m);
-
-            var subsidiaryCompanies = detailsPage.FindPaymentLineItem("Subsidiary companies");
-            subsidiaryCompanies.Should().NotBeNull();
-            subsidiaryCompanies!.Units.Should().Be(subsidiaryClrCount);
-            subsidiaryCompanies.Amount.Should().Be(netSubsidiaryFeePence / 100m);
-
-            var subsidiaryClr = detailsPage.FindPaymentLineItem("Subsidiaries closed loop packaging waste");
-            subsidiaryClr.Should().NotBeNull();
-            subsidiaryClr!.Units.Should().Be(subsidiaryClrCount);
-            subsidiaryClr.Amount.Should().Be(subsidiaryClrFeePence / 100m);
-        }
-    }
-
-    [Fact]
-    public async Task RegistrationSubmissionDetailsPage_ShowsDirectProducerSubsidiaryClrPaymentLineItems()
-    {
-        // Arrange
-        var submissionId = Guid.NewGuid();
-        const int producerRegistrationFeePence = 284200;
-        const int lateRegistrationFeePence = 77200;
-        const int producerClosedLoopRecyclingFeePence = 254800;
-        const int subsidiariesFeePence = 647600;
-        const int subsidiaryClrFeePence = 509600;
-        const int subsidiaryClrCount = 2;
-        const int totalFeePence = 1264800;
-        const int outstandingPaymentPence = 1264800;
-        const int netSubsidiaryFeePence = subsidiariesFeePence - subsidiaryClrFeePence;
-
-        SetupFacadeMockRegistrationSubmissionDetails(
-            RegistrationSubmissionDetailsBuilder.Default(submissionId)
-                .AsDirectLargeProducer()
-                .WithProducerSubsidiaries(subsidiaryClrCount)
-                .WithProducerClosedLoopRecycling(subsidiaryClrCount));
-
-        SetupPaymentFacadeMockProducerRegistrationFee(
-            ProducerPaymentResponseBuilder.Default()
-                .WithProducerRegistrationFee(producerRegistrationFeePence)
-                .WithProducerLateRegistrationFee(lateRegistrationFeePence)
-                .WithProducerClosedLoopRecyclingFee(producerClosedLoopRecyclingFeePence)
-                .WithTotalFee(totalFeePence)
-                .WithOutstandingPayment(outstandingPaymentPence)
-                .WithSubsidiariesFeeBreakdown(
-                    subsidiariesFeePence,
-                    subsidiaryClrFeePence,
-                    subsidiaryClrCount));
-
-        // Act
-        var detailsPage = await GetAsPageModel<ManageRegistrationSubmissionDetailsPageModel>(
-            $"/regulators/registration-submission-details/{submissionId}");
-
-        // Assert
-        using (new AssertionScope())
-        {
-            var subsidiaryCompanies = detailsPage.FindPaymentLineItem("Subsidiary companies");
-            subsidiaryCompanies.Should().NotBeNull();
-            subsidiaryCompanies!.Units.Should().Be(subsidiaryClrCount);
-            subsidiaryCompanies.Amount.Should().Be(netSubsidiaryFeePence / 100m);
-
-            var subsidiaryClr = detailsPage.FindPaymentLineItem("Subsidiaries closed loop packaging waste");
-            subsidiaryClr.Should().NotBeNull();
-            subsidiaryClr!.Units.Should().Be(subsidiaryClrCount);
-            subsidiaryClr.Amount.Should().Be(subsidiaryClrFeePence / 100m);
-        }
-    }
-
-    private void SetupPaymentFacadeMockComplianceSchemeRegistrationFee(CompliancePaymentResponseBuilder builder) =>
-        FacadeServer.Given(Request.Create()
-                .UsingPost()
-                .WithPath("/compliance-scheme/registration-fee"))
-            .RespondWith(Response.Create()
-                .WithStatusCode(200)
-                .WithHeader("Content-Type", "application/json")
-                .WithBody(JsonSerializer.Serialize(builder.Build())));
-
-    private void SetupPaymentFacadeMockProducerRegistrationFee(ProducerPaymentResponseBuilder? builder = null) =>
-        FacadeServer.Given(Request.Create()
-                .UsingPost()
-                .WithPath("/producer/registration-fee"))
-            .RespondWith(Response.Create()
-                .WithStatusCode(200)
-                .WithHeader("Content-Type", "application/json")
-                .WithBody(JsonSerializer.Serialize((builder ?? ProducerPaymentResponseBuilder.Default()).Build())));
-
-    private void SetupFacadeMockRegistrationSubmissionDetails(RegistrationSubmissionDetailsBuilder builder) =>
-        FacadeServer.Given(Request.Create()
-                .UsingGet()
-                .WithPath($"/api/organisation-registration-submission-details/{builder.SubmissionId}"))
-            .RespondWith(Response.Create()
-                .WithStatusCode(200)
-                .WithHeader("Content-Type", "application/json")
-                .WithBody(JsonSerializer.Serialize(builder.Build())));
 }

--- a/src/IntegrationTests/Features/RegistrationSubmissionDetailsTests.cs
+++ b/src/IntegrationTests/Features/RegistrationSubmissionDetailsTests.cs
@@ -175,6 +175,7 @@ public class RegistrationSubmissionDetailsTests : IntegrationTestBase
         const int subsidiariesFeePence = 647600;
         const int subsidiaryClrFeePence = 509600;
         const int subsidiaryClrCount = 2;
+        const int netSubsidiaryFeePence = subsidiariesFeePence - subsidiaryClrFeePence;
 
         SetupFacadeMockRegistrationSubmissionDetails(
             RegistrationSubmissionDetailsBuilder.Default(submissionId)
@@ -207,7 +208,7 @@ public class RegistrationSubmissionDetailsTests : IntegrationTestBase
             var subsidiaryCompanies = detailsPage.FindPaymentLineItem("Subsidiary companies");
             subsidiaryCompanies.Should().NotBeNull();
             subsidiaryCompanies!.Units.Should().Be(subsidiaryClrCount);
-            subsidiaryCompanies.Amount.Should().Be(subsidiariesFeePence / 100m);
+            subsidiaryCompanies.Amount.Should().Be(netSubsidiaryFeePence / 100m);
 
             var subsidiaryClr = detailsPage.FindPaymentLineItem("Subsidiaries closed loop packaging waste");
             subsidiaryClr.Should().NotBeNull();

--- a/src/IntegrationTests/Infrastructure/PaymentFacadeRequestAssertions.cs
+++ b/src/IntegrationTests/Infrastructure/PaymentFacadeRequestAssertions.cs
@@ -1,0 +1,24 @@
+namespace IntegrationTests.Infrastructure;
+
+using WireMock.AwesomeAssertions;
+using WireMock.Matchers;
+using WireMock.Server;
+
+internal static class PaymentFacadeRequestAssertions
+{
+    internal static void ShouldHavePostedProducerRegistrationFee(
+        this WireMockServer facadeServer,
+        object expectedPartialBody) =>
+        facadeServer.Should().HaveReceivedACall()
+            .UsingPost().And
+            .AtPath("/producer/registration-fee").And
+            .WithBodyAsJson(new JsonPartialMatcher(expectedPartialBody));
+
+    internal static void ShouldHavePostedComplianceSchemeRegistrationFee(
+        this WireMockServer facadeServer,
+        object expectedPartialBody) =>
+        facadeServer.Should().HaveReceivedACall()
+            .UsingPost().And
+            .AtPath("/compliance-scheme/registration-fee").And
+            .WithBodyAsJson(new JsonPartialMatcher(expectedPartialBody));
+}

--- a/src/IntegrationTests/Infrastructure/RegistrationSubmissionPaymentMocks.cs
+++ b/src/IntegrationTests/Infrastructure/RegistrationSubmissionPaymentMocks.cs
@@ -1,0 +1,43 @@
+namespace IntegrationTests.Infrastructure;
+
+using System.Text.Json;
+using Builders;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+internal static class RegistrationSubmissionPaymentMocks
+{
+    internal static void SetupRegistrationSubmissionDetails(
+        this WireMockServer facadeServer,
+        RegistrationSubmissionDetailsBuilder builder) =>
+        facadeServer.Given(Request.Create()
+                .UsingGet()
+                .WithPath($"/api/organisation-registration-submission-details/{builder.SubmissionId}"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(JsonSerializer.Serialize(builder.Build())));
+
+    internal static void SetupComplianceSchemeRegistrationFee(
+        this WireMockServer facadeServer,
+        CompliancePaymentResponseBuilder builder) =>
+        facadeServer.Given(Request.Create()
+                .UsingPost()
+                .WithPath("/compliance-scheme/registration-fee"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(JsonSerializer.Serialize(builder.Build())));
+
+    internal static void SetupProducerRegistrationFee(
+        this WireMockServer facadeServer,
+        ProducerPaymentResponseBuilder? builder = null) =>
+        facadeServer.Given(Request.Create()
+                .UsingPost()
+                .WithPath("/producer/registration-fee"))
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody(JsonSerializer.Serialize((builder ?? ProducerPaymentResponseBuilder.Default()).Build())));
+}

--- a/src/IntegrationTests/PageModels/ManageRegistrationSubmissionDetailsPageModel.cs
+++ b/src/IntegrationTests/PageModels/ManageRegistrationSubmissionDetailsPageModel.cs
@@ -92,7 +92,7 @@ public class ManageRegistrationSubmissionDetailsPageModel : PageModelBase, IPage
         // The tag helper renders amounts as <dd class="govuk-summary-list__actions"> with £X,XXX.XX format
         var amounts = paymentCard.QuerySelectorAll("dd.govuk-summary-list__actions")
             .Select(dd => dd.TextContent.Trim())
-            .Where(text => text.StartsWith("£") || text.Contains("£"))
+            .Where(text => text.StartsWith('£') || text.Contains('£'))
             .ToList();
 
         return new PaymentDetailsUnderTest
@@ -149,6 +149,28 @@ public class ManageRegistrationSubmissionDetailsPageModel : PageModelBase, IPage
 
         return null;
     }
+
+    public PaymentLineItemUnderTest? FindDirectProducerHoldingCompanyClrLine()
+    {
+        var item = FindPaymentLineItem("Closed loop packaging waste");
+        return item is not null &&
+               !item.Description.Contains("Subsidiaries", StringComparison.OrdinalIgnoreCase)
+            ? item
+            : null;
+    }
+
+    public PaymentLineItemUnderTest? FindCsoHoldingCompanyClrLine() =>
+        FindPaymentLineItem("Producer closed loop packaging waste")
+        ?? FindPaymentLineItem("Producers closed loop packaging waste");
+
+    public PaymentLineItemUnderTest? FindSubsidiaryClrLine() =>
+        FindPaymentLineItem("Subsidiaries closed loop packaging waste");
+
+    public PaymentLineItemUnderTest? FindSubsidiaryCompaniesLine() =>
+        FindPaymentLineItem("Subsidiary companies");
+
+    public PaymentLineItemUnderTest? FindLargeProducersLine() =>
+        FindPaymentLineItem("Large producers");
 
     private IElement? GetPaymentCard() =>
         _document.QuerySelectorAll("div.govuk-summary-card")


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/AMCR-291

**What**
- Fixes incorrect closed-loop recycling (CLR) and subsidiary fee display for CSO compliance scheme payment details.
- CLR count now comes from `ProducerDetails.NumberOfHoldingCompaniesClosedLoopRecycling` instead of counting members returned with a CLR fee.
- CLR unit fee uses the maximum `ClosedLoopRecyclingFee` across members (not the sum), with DefaultIfEmpty(0) so empty member lists no longer throw on .Max().
- Subsidiary company fee temporarily sums raw `SubsidiaryFee` values (OMP/CLR breakdown netting via `SubsidiaryFeeHelper` is disabled pending payment API changes).
- Payment request mapping sets `NoOfSubsidiariesClosedLoopRecycling` to 0 for CSO large producer members.
- Added integration tests to cover multiple Producer/CSO with mixed CLR scenarios

**Why**
- For CSO submissions with multiple holding companies and subsidiaries, the payment details view showed incorrect CLR counts and fees. Summing member-level CLR fees and deriving the count from the payment response did not match the submitted registration data. Using the producer-level holding company count and the unit CLR fee aligns the display with what was registered.
- Subsidiary fee breakdown data from the payment API is not yet reliable for netting OMP/CLR, so subsidiary company fees use the gross SubsidiaryFee until breakdown support is restored.