### PR TITLE
Amcr 298 display correct clr fees for subsidiaries

### DIFF
--- a/src/EPR.RegulatorService.Frontend.Core/Models/RegistrationSubmissions/FacadeCommonData/CsoMembershipDetailsDto.cs
+++ b/src/EPR.RegulatorService.Frontend.Core/Models/RegistrationSubmissions/FacadeCommonData/CsoMembershipDetailsDto.cs
@@ -6,6 +6,7 @@ public class CsoMembershipDetailsDto
     public string MemberType { get; set; }
     public bool IsOnlineMarketPlace { get; set; }
     public bool IsLateFeeApplicable { get; set; }
+    public bool IsClosedLoopRecycling { get; set; }
     public int? NumberOfHoldingCompaniesClosedLoopRecycling { get; set; }
 
     public int NumberOfSubsidiariesClosedLoopRecycling { get; set; }
@@ -23,8 +24,8 @@ public class CsoMembershipDetailsDto
         MemberType = dto.MemberType,
         IsOnlineMarketplace = dto.IsOnlineMarketPlace,
         IsLateFeeApplicable = dto.IsLateFeeApplicable,
-        NoOfHoldingCompaniesClosedLoopRecycling = dto.NumberOfHoldingCompaniesClosedLoopRecycling ?? 0,
-        IsClosedLoopRecycling = (dto.NumberOfHoldingCompaniesClosedLoopRecycling ?? 0) > 0,
+        NoOfHoldingCompaniesClosedLoopRecycling = dto.IsClosedLoopRecycling ? 1 : 0,
+        IsClosedLoopRecycling = dto.IsClosedLoopRecycling,
         NoOfSubsidiariesClosedLoopRecycling = dto.NumberOfSubsidiariesClosedLoopRecycling,
         NoOfSubsidiariesOnlineMarketplace = dto.NumberOfSubsidiariesOnlineMarketPlace,
         NumberOfSubsidiaries = dto.NumberOfSubsidiaries

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Core/Models/RegistrationSubmissions/FacadeCommonData/CsoMembershipDetailsDtoTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Core/Models/RegistrationSubmissions/FacadeCommonData/CsoMembershipDetailsDtoTests.cs
@@ -17,6 +17,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Models.RegistrationSubmis
             Assert.IsNull(dto.MemberType);
             Assert.IsFalse(dto.IsOnlineMarketPlace);
             Assert.IsFalse(dto.IsLateFeeApplicable);
+            Assert.IsFalse(dto.IsClosedLoopRecycling);
             Assert.IsNull(dto.NumberOfHoldingCompaniesClosedLoopRecycling);
             Assert.AreEqual(0, dto.NumberOfSubsidiaries);
             Assert.AreEqual(0, dto.NumberOfSubsidiariesClosedLoopRecycling);
@@ -34,6 +35,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Models.RegistrationSubmis
             var memberType = "TypeA";
             var isOnlineMarketplace = true;
             var isLateFeeApplicable = true;
+            var isClosedLoopRecycling = true;
             var numberOfHoldingCompaniesClosedLoopRecycling = 2;
             var numberOfSubsidiaries = 5;
             var numberOfSubsidiariesClosedLoopRecycling = 3;
@@ -49,6 +51,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Models.RegistrationSubmis
                 MemberType = memberType,
                 IsOnlineMarketPlace = isOnlineMarketplace,
                 IsLateFeeApplicable = isLateFeeApplicable,
+                IsClosedLoopRecycling = isClosedLoopRecycling,
                 NumberOfHoldingCompaniesClosedLoopRecycling = numberOfHoldingCompaniesClosedLoopRecycling,
                 NumberOfSubsidiaries = numberOfSubsidiaries,
                 NumberOfSubsidiariesClosedLoopRecycling = numberOfSubsidiariesClosedLoopRecycling,
@@ -63,6 +66,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Models.RegistrationSubmis
             Assert.AreEqual(memberType, dto.MemberType);
             Assert.AreEqual(isOnlineMarketplace, dto.IsOnlineMarketPlace);
             Assert.AreEqual(isLateFeeApplicable, dto.IsLateFeeApplicable);
+            Assert.AreEqual(isClosedLoopRecycling, dto.IsClosedLoopRecycling);
             Assert.AreEqual(numberOfHoldingCompaniesClosedLoopRecycling, dto.NumberOfHoldingCompaniesClosedLoopRecycling);
             Assert.AreEqual(numberOfSubsidiaries, dto.NumberOfSubsidiaries);
             Assert.AreEqual(numberOfSubsidiariesClosedLoopRecycling, dto.NumberOfSubsidiariesClosedLoopRecycling);
@@ -109,6 +113,7 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Models.RegistrationSubmis
                 MemberType = "Large",
                 IsOnlineMarketPlace = true,
                 IsLateFeeApplicable = false,
+                IsClosedLoopRecycling = true,
                 NumberOfHoldingCompaniesClosedLoopRecycling = 1,
                 NumberOfSubsidiaries = 5,
                 NumberOfSubsidiariesClosedLoopRecycling = 4,
@@ -167,14 +172,15 @@ namespace EPR.RegulatorService.Frontend.UnitTests.Core.Models.RegistrationSubmis
         }
 
         [TestMethod]
-        public void ImplicitOperator_ShouldHandleNullNumberOfHoldingCompaniesClosedLoopRecycling_OnDto()
+        public void ImplicitOperator_ShouldUseIsClosedLoopRecycling_ForClosedLoopFlags()
         {
             // Arrange
             var dto = new CsoMembershipDetailsDto
             {
                 MemberId = "M12345",
                 MemberType = "Large",
-                NumberOfHoldingCompaniesClosedLoopRecycling = null,
+                IsClosedLoopRecycling = false,
+                NumberOfHoldingCompaniesClosedLoopRecycling = 2,
             };
 
             // Act

--- a/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/CompliancePaymentDetailsViewComponentTests.cs
+++ b/src/EPR.RegulatorService.Frontend.UnitTests/Web/ViewComponents/CompliancePaymentDetailsViewComponentTests.cs
@@ -147,7 +147,7 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
     [TestMethod]
     [DataRow(false)]
     [DataRow(true)]
-    public async Task InvokeAsync_Passes_HoldingCompanyClosedLoopRecycling_And_Zeros_SubsidiariesClosedLoopRecycling_For_CsoLargeProducer(
+    public async Task InvokeAsync_Passes_HoldingCompanyClosedLoopRecycling_And_SubsidiariesClosedLoopRecycling_FromFacade_For_CsoLargeProducer(
         bool isResubmission)
     {
         // Arrange
@@ -162,9 +162,9 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
             {
                 MemberId = "memberid1",
                 MemberType = "large",
-                NumberOfHoldingCompaniesClosedLoopRecycling = 1,
-                NumberOfSubsidiaries = 1,
-                NumberOfSubsidiariesClosedLoopRecycling = 7
+                IsClosedLoopRecycling = true,
+                NumberOfSubsidiaries = 3,
+                NumberOfSubsidiariesClosedLoopRecycling = 3
             }
         ];
         _registrationSumissionDetailsViewModel.SubmissionDetails = new SubmissionDetailsViewModel
@@ -194,8 +194,43 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
         var members = capturedRequest!.ComplianceSchemeMembers!.ToList();
         members.Should().ContainSingle();
         members[0].NoOfHoldingCompaniesClosedLoopRecycling.Should().Be(1);
-        members[0].NoOfSubsidiariesClosedLoopRecycling.Should().Be(0);
+        members[0].NoOfSubsidiariesClosedLoopRecycling.Should().Be(3);
         members[0].IsClosedLoopRecycling.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task InvokeAsync_Passes_PerMemberSubsidiariesClosedLoopRecycling_FromFacade_For_CsoLargeProducer()
+    {
+        CompliancePaymentRequest? capturedRequest = null;
+        _registrationSumissionDetailsViewModel.RegistrationJourneyType = RegistrationJourneyType.CsoLargeProducer;
+        _registrationSumissionDetailsViewModel.CSOMembershipDetails =
+        [
+            new CsoMembershipDetailsDto
+            {
+                MemberId = "memberid1",
+                MemberType = "large",
+                NumberOfSubsidiaries = 1,
+                NumberOfSubsidiariesClosedLoopRecycling = 7
+            }
+        ];
+        _registrationSumissionDetailsViewModel.SubmissionDetails = new SubmissionDetailsViewModel
+        {
+            TimeAndDateOfSubmission = DateTime.UtcNow.AddDays(-1)
+        };
+        _paymentFacadeServiceMock.Setup(x => x.GetCompliancePaymentDetailsAsync(It.IsAny<CompliancePaymentRequest>()))
+            .Callback<CompliancePaymentRequest>(r => capturedRequest = r)
+            .ReturnsAsync(new CompliancePaymentResponse
+            {
+                ComplianceSchemeMembers =
+                [
+                    new() { MemberId = "memberid1", MemberType = "large", MemberFee = 2.00M }
+                ]
+            });
+
+        await _sut.InvokeAsync(_registrationSumissionDetailsViewModel);
+
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.ComplianceSchemeMembers!.Single().NoOfSubsidiariesClosedLoopRecycling.Should().Be(7);
     }
 
     [TestMethod]
@@ -315,7 +350,7 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
             {
                 MemberId = "memberid1",
                 MemberType = "large",
-                NumberOfHoldingCompaniesClosedLoopRecycling = 1,
+                IsClosedLoopRecycling = true,
                 NumberOfSubsidiaries = 0
             }
         ];
@@ -338,18 +373,18 @@ public class CompliancePaymentDetailsViewComponentTests : ViewComponentsTestBase
     }
 
     [TestMethod]
-    public async Task InvokeAsync_SetsIsClosedLoopRecycling_ForFirstNLargeMembers_WhenMultipleHoldingCompaniesHaveClr()
+    public async Task InvokeAsync_SetsIsClosedLoopRecycling_FromPerMemberFlag()
     {
         // Arrange
         CompliancePaymentRequest? capturedRequest = null;
         _registrationSumissionDetailsViewModel.RegistrationJourneyType = RegistrationJourneyType.CsoLargeProducer;
         _registrationSumissionDetailsViewModel.CSOMembershipDetails =
         [
-            new CsoMembershipDetailsDto { MemberId = "member1", MemberType = "large", NumberOfHoldingCompaniesClosedLoopRecycling = 3 },
-            new CsoMembershipDetailsDto { MemberId = "member2", MemberType = "large", NumberOfHoldingCompaniesClosedLoopRecycling = 3 },
-            new CsoMembershipDetailsDto { MemberId = "member3", MemberType = "large", NumberOfHoldingCompaniesClosedLoopRecycling = 3 },
-            new CsoMembershipDetailsDto { MemberId = "member4", MemberType = "large", NumberOfHoldingCompaniesClosedLoopRecycling = 3 },
-            new CsoMembershipDetailsDto { MemberId = "member5", MemberType = "small", NumberOfHoldingCompaniesClosedLoopRecycling = 3 }
+            new CsoMembershipDetailsDto { MemberId = "member1", MemberType = "large", IsClosedLoopRecycling = true },
+            new CsoMembershipDetailsDto { MemberId = "member2", MemberType = "large", IsClosedLoopRecycling = true },
+            new CsoMembershipDetailsDto { MemberId = "member3", MemberType = "large", IsClosedLoopRecycling = true },
+            new CsoMembershipDetailsDto { MemberId = "member4", MemberType = "large", IsClosedLoopRecycling = false },
+            new CsoMembershipDetailsDto { MemberId = "member5", MemberType = "small", IsClosedLoopRecycling = false }
         ];
         _registrationSumissionDetailsViewModel.SubmissionDetails = new SubmissionDetailsViewModel
         {

--- a/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/CompliancePaymentDetailsViewComponent.cs
+++ b/src/EPR.RegulatorService.Frontend.Web/ViewComponents/RegistrationSubmissions/CompliancePaymentDetailsViewComponent.cs
@@ -35,7 +35,7 @@ public class CompliancePaymentDetailsViewComponent(
                 {
                     ApplicationReferenceNumber = viewModel.ReferenceNumber,
                     Regulator = viewModel.NationCode,
-                    ComplianceSchemeMembers = MapToComplianceSchemeMemberRequests(csoMembers, viewModel),
+                    ComplianceSchemeMembers = MapToComplianceSchemeMemberRequests(csoMembers),
                     SubmissionDate = TimeZoneInfo.ConvertTimeToUtc(viewModel.IsResubmission
                         ? viewModel.SubmissionDetails.TimeAndDateOfResubmission.GetValueOrDefault()
                         : viewModel.SubmissionDetails.TimeAndDateOfSubmission),
@@ -104,39 +104,22 @@ public class CompliancePaymentDetailsViewComponent(
     }
 
     private static List<ComplianceSchemeMemberRequest> MapToComplianceSchemeMemberRequests(
-        IReadOnlyList<CsoMembershipDetailsDto> csoMembers,
-        RegistrationSubmissionDetailsViewModel viewModel)
-    {
-        int holdingCompanyClosedLoopRecyclingCount =
-            viewModel.RegistrationJourneyType == RegistrationJourneyType.CsoLargeProducer && csoMembers.Count > 0
-                ? csoMembers[0].NumberOfHoldingCompaniesClosedLoopRecycling ?? 0
-                : 0;
-
-        return csoMembers
-            .Select((csoMember, index) => MapToComplianceSchemeMemberRequest(
-                csoMember,
-                IsHoldingCompanyClosedLoopRecyclingMember(csoMember, index, holdingCompanyClosedLoopRecyclingCount)))
-            .ToList();
-    }
-
-    private static bool IsHoldingCompanyClosedLoopRecyclingMember(
-        CsoMembershipDetailsDto csoMember,
-        int index,
-        int holdingCompanyClosedLoopRecyclingCount) =>
-        index < holdingCompanyClosedLoopRecyclingCount && csoMember is { MemberType: "large" };
+        IReadOnlyList<CsoMembershipDetailsDto> csoMembers) =>
+        csoMembers.Select(MapToComplianceSchemeMemberRequest).ToList();
 
     private static ComplianceSchemeMemberRequest MapToComplianceSchemeMemberRequest(
-        CsoMembershipDetailsDto csoMember,
-        bool isClosedLoopRecycling) =>
+        CsoMembershipDetailsDto csoMember) =>
         new()
         {
             MemberId = csoMember.MemberId,
             MemberType = csoMember.MemberType,
             IsOnlineMarketplace = csoMember.IsOnlineMarketPlace,
             IsLateFeeApplicable = csoMember.IsLateFeeApplicable,
-            IsClosedLoopRecycling = isClosedLoopRecycling,
-            NoOfHoldingCompaniesClosedLoopRecycling = isClosedLoopRecycling ? 1 : 0,
-            NoOfSubsidiariesClosedLoopRecycling = 0,
+            IsClosedLoopRecycling = csoMember.IsClosedLoopRecycling,
+            NoOfHoldingCompaniesClosedLoopRecycling = csoMember.IsClosedLoopRecycling ? 1 : 0,
+            NoOfSubsidiariesClosedLoopRecycling = csoMember is { MemberType: "large" }
+                ? csoMember.NumberOfSubsidiariesClosedLoopRecycling
+                : 0,
             NumberOfSubsidiaries = csoMember.NumberOfSubsidiaries,
             NoOfSubsidiariesOnlineMarketplace = csoMember.NumberOfSubsidiariesOnlineMarketPlace
         };

--- a/src/IntegrationTests/Builders/CsoMemberBuilder.cs
+++ b/src/IntegrationTests/Builders/CsoMemberBuilder.cs
@@ -5,7 +5,7 @@ public class CsoMemberBuilder
     private readonly string _memberId;
     private string _memberType = "large";
     private int _numberOfSubsidiaries;
-    private int _numberOfHoldingCompaniesClosedLoopRecycling;
+    private bool _isClosedLoopRecycling;
     private int _numberOfSubsidiariesClosedLoopRecycling;
 
     private CsoMemberBuilder(string memberId)
@@ -27,17 +27,14 @@ public class CsoMemberBuilder
         return this;
     }
 
-    /// <summary>
-    /// Holding-company CLR count on the first CSO member drives how many large members receive the CLR flag.
-    /// </summary>
-    public CsoMemberBuilder WithHoldingCompanyClrCount(int count)
+    public CsoMemberBuilder WithIsClosedLoopRecycling(bool isClosedLoopRecycling = true)
     {
-        _numberOfHoldingCompaniesClosedLoopRecycling = count;
+        _isClosedLoopRecycling = isClosedLoopRecycling;
         return this;
     }
 
     /// <summary>
-    /// Facade-only subsidiary CLR count; must not be forwarded to the payment API request.
+    /// Subsidiary CLR count from facade data; forwarded to the payment API request per member.
     /// </summary>
     public CsoMemberBuilder WithSubsidiariesClosedLoopRecycling(int count)
     {
@@ -51,8 +48,8 @@ public class CsoMemberBuilder
         memberType = _memberType,
         isOnlineMarketPlace = false,
         isLateFeeApplicable = true,
-        numberOfHoldingCompaniesClosedLoopRecycling = _numberOfHoldingCompaniesClosedLoopRecycling,
-        NumberOfSubsidiariesClosedLoopRecycling = _numberOfSubsidiariesClosedLoopRecycling,
+        isClosedLoopRecycling = _isClosedLoopRecycling,
+        numberOfSubsidiariesClosedLoopRecycling = _numberOfSubsidiariesClosedLoopRecycling,
         numberOfSubsidiaries = _numberOfSubsidiaries,
         NumberOfSubsidiariesOnlineMarketPlace = 0,
         relevantYear,

--- a/src/IntegrationTests/Builders/RegistrationSubmissionDetailsBuilder.cs
+++ b/src/IntegrationTests/Builders/RegistrationSubmissionDetailsBuilder.cs
@@ -14,7 +14,7 @@ public class RegistrationSubmissionDetailsBuilder
     private string? _organisationSize;
     private int _numberOfSubsidiariesClosedLoopRecyclingRoot;
     private int _numberOfHoldingCompaniesClosedLoopRecyclingRoot;
-    private int _csoMemberNumberOfHoldingCompaniesClosedLoopRecycling;
+    private bool _csoMemberIsClosedLoopRecycling;
     private int _csoMemberNumberOfSubsidiariesClosedLoopRecycling;
     private int _numberOfSubsidiariesRoot;
     private int _csoMemberNumberOfSubsidiaries;
@@ -93,10 +93,10 @@ public class RegistrationSubmissionDetailsBuilder
 
     public RegistrationSubmissionDetailsBuilder WithCsoMemberClosedLoopRecycling(
         int noOfSubsidiariesClosedLoopRecycling,
-        int memberNoOfHoldingCompaniesClosedLoopRecycling = 1)
+        bool isClosedLoopRecycling = true)
     {
         _csoMemberNumberOfSubsidiariesClosedLoopRecycling = noOfSubsidiariesClosedLoopRecycling;
-        _csoMemberNumberOfHoldingCompaniesClosedLoopRecycling = memberNoOfHoldingCompaniesClosedLoopRecycling;
+        _csoMemberIsClosedLoopRecycling = isClosedLoopRecycling;
         return this;
     }
 
@@ -237,8 +237,8 @@ public class RegistrationSubmissionDetailsBuilder
                 memberType = _csoMemberType,
                 isOnlineMarketPlace = false,
                 isLateFeeApplicable = true,
-                numberOfHoldingCompaniesClosedLoopRecycling = _csoMemberNumberOfHoldingCompaniesClosedLoopRecycling,
-                NumberOfSubsidiariesClosedLoopRecycling = _csoMemberNumberOfSubsidiariesClosedLoopRecycling,
+                isClosedLoopRecycling = _csoMemberIsClosedLoopRecycling,
+                numberOfSubsidiariesClosedLoopRecycling = _csoMemberNumberOfSubsidiariesClosedLoopRecycling,
                 numberOfSubsidiaries = _csoMemberNumberOfSubsidiaries,
                 NumberOfSubsidiariesOnlineMarketPlace = 0,
                 relevantYear = _relevantYear,

--- a/src/IntegrationTests/Features/ClrPaymentScenarioIds.cs
+++ b/src/IntegrationTests/Features/ClrPaymentScenarioIds.cs
@@ -17,6 +17,8 @@ internal static class ClrPaymentScenarioIds
     internal static readonly Guid Scenario13 = Guid.Parse("a5e6f7b8-c9d0-1234-efab-345678901234");
     internal static readonly Guid Scenario14 = Guid.Parse("b6f7a8c9-d0e1-2345-fabc-456789012345");
     internal static readonly Guid Scenario15 = Guid.Parse("c7a8b9d0-e1f2-3456-abcd-567890123456");
+    internal static readonly Guid Scenario16 = Guid.Parse("d8b9c0e1-f2a3-4567-bcde-678901234567");
+    internal static readonly Guid Scenario17 = Guid.Parse("e9c0d1f2-a3b4-5678-cdef-789012345678");
 
     internal static string AppRef(int scenario) => $"REG-SCENARIO-{scenario:D2}";
 }

--- a/src/IntegrationTests/Features/ClrPaymentScenarioTests.cs
+++ b/src/IntegrationTests/Features/ClrPaymentScenarioTests.cs
@@ -238,7 +238,7 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
 
     [Fact]
     [Trait("Scenario", "06")]
-    public async Task Cso_1Member_HcClrOn_SubClrOff_DisplaysHcClrLine_AndZerosSubClrInRequest()
+    public async Task Cso_1Member_HcClrOn_SubClrOff_DisplaysHcClrLine_AndPostsSubClrZeroInRequest()
     {
         const int scenario = 6;
         var submissionId = ClrPaymentScenarioIds.Scenario06;
@@ -251,7 +251,7 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
                 .WithRegistrationJourneyType("CsoLargeProducer")
                 .WithApplicationReferenceNumber(appRef)
                 .WithCsoMemberSubsidiaries(1)
-                .WithCsoMemberClosedLoopRecycling(8));
+                .WithCsoMemberClosedLoopRecycling(0, isClosedLoopRecycling: true));
 
         FacadeServer.SetupComplianceSchemeRegistrationFee(
             CompliancePaymentResponseBuilder.Default()
@@ -342,7 +342,7 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
     [Fact]
     [Trait("Scenario", "08")]
     [Trait("Category", "AMCR-291")]
-    public async Task Cso_3Members_3SubsEach_HcClr3_SubClr3_DisplaysAggregatedClrFees_AndZerosSubClrInRequest()
+    public async Task Cso_3Members_3SubsEach_HcClr3_SubClr3_DisplaysAggregatedClrFees_AndPostsSubClrInRequest()
     {
         const int scenario = 8;
         var submissionId = ClrPaymentScenarioIds.Scenario08;
@@ -357,13 +357,15 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
                 .WithApplicationReferenceNumber(appRef)
                 .WithCsoMembers(
                     CsoMemberBuilder.Large("100001")
-                        .WithHoldingCompanyClrCount(3)
+                        .WithIsClosedLoopRecycling()
                         .WithSubsidiaries(3)
                         .WithSubsidiariesClosedLoopRecycling(3),
                     CsoMemberBuilder.Large("100002")
+                        .WithIsClosedLoopRecycling()
                         .WithSubsidiaries(3)
                         .WithSubsidiariesClosedLoopRecycling(3),
                     CsoMemberBuilder.Large("100003")
+                        .WithIsClosedLoopRecycling()
                         .WithSubsidiaries(3)
                         .WithSubsidiariesClosedLoopRecycling(3)));
 
@@ -390,9 +392,9 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
             applicationReferenceNumber = appRef,
             complianceSchemeMembers = new[]
             {
-                new { memberId = "100001", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1, noOfSubsidiariesClosedLoopRecycling = 0 },
-                new { memberId = "100002", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1, noOfSubsidiariesClosedLoopRecycling = 0 },
-                new { memberId = "100003", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1, noOfSubsidiariesClosedLoopRecycling = 0 },
+                new { memberId = "100001", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1, noOfSubsidiariesClosedLoopRecycling = 3 },
+                new { memberId = "100002", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1, noOfSubsidiariesClosedLoopRecycling = 3 },
+                new { memberId = "100003", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1, noOfSubsidiariesClosedLoopRecycling = 3 },
             },
         });
     }
@@ -536,7 +538,7 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
 
     [Fact]
     [Trait("Scenario", "12")]
-    public async Task Cso_3LargeMembers_HcClr2_SubClrOff_FlagsFirstTwoMembersOnly_AndDisplaysHcClrLine()
+    public async Task Cso_3LargeMembers_HcClr2_SubClrOff_UsesPerMemberHcClrFlags_AndDisplaysHcClrLine()
     {
         const int scenario = 12;
         var submissionId = ClrPaymentScenarioIds.Scenario12;
@@ -547,8 +549,8 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
             RegistrationSubmissionDetailsBuilder.Default(submissionId)
                 .WithApplicationReferenceNumber(appRef)
                 .WithCsoMembers(
-                    CsoMemberBuilder.Large("100001").WithHoldingCompanyClrCount(2),
-                    CsoMemberBuilder.Large("100002"),
+                    CsoMemberBuilder.Large("100001").WithIsClosedLoopRecycling(),
+                    CsoMemberBuilder.Large("100002").WithIsClosedLoopRecycling(),
                     CsoMemberBuilder.Large("100003")));
 
         FacadeServer.SetupComplianceSchemeRegistrationFee(
@@ -596,8 +598,8 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
             RegistrationSubmissionDetailsBuilder.Default(submissionId)
                 .WithApplicationReferenceNumber(appRef)
                 .WithCsoMembers(
-                    CsoMemberBuilder.Large("100001").WithHoldingCompanyClrCount(2),
-                    CsoMemberBuilder.Large("100002"),
+                    CsoMemberBuilder.Large("100001").WithIsClosedLoopRecycling(),
+                    CsoMemberBuilder.Large("100002").WithIsClosedLoopRecycling(),
                     CsoMemberBuilder.Large("100003").WithMemberType("small")));
 
         FacadeServer.SetupComplianceSchemeRegistrationFee(
@@ -636,7 +638,7 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
 
     [Fact]
     [Trait("Scenario", "14")]
-    public async Task Cso_3Members_3SubsEach_HcClrOff_SubClrMixed_DisplaysAggregatedPartialSubClr_AndZerosSubClrInRequest()
+    public async Task Cso_3Members_3SubsEach_HcClrOff_SubClrMixed_DisplaysAggregatedPartialSubClr_AndPostsSubClrInRequest()
     {
         const int scenario = 14;
         var submissionId = ClrPaymentScenarioIds.Scenario14;
@@ -681,8 +683,8 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
             applicationReferenceNumber = appRef,
             complianceSchemeMembers = new[]
             {
-                new { memberId = "100001", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 0 },
-                new { memberId = "100002", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 0 },
+                new { memberId = "100001", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 3 },
+                new { memberId = "100002", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 1 },
                 new { memberId = "100003", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 0 },
             },
         });
@@ -690,7 +692,7 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
 
     [Fact]
     [Trait("Scenario", "15")]
-    public async Task Cso_3Members_3SubsEach_HcClr2_SubClrMixed_DisplaysBothClrTypes_AndZerosSubClrInRequest()
+    public async Task Cso_3Members_3SubsEach_HcClr2_SubClrMixed_DisplaysBothClrTypes_AndPostsSubClrInRequest()
     {
         const int scenario = 15;
         var submissionId = ClrPaymentScenarioIds.Scenario15;
@@ -709,10 +711,11 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
                 .WithApplicationReferenceNumber(appRef)
                 .WithCsoMembers(
                     CsoMemberBuilder.Large("100001")
-                        .WithHoldingCompanyClrCount(2)
+                        .WithIsClosedLoopRecycling()
                         .WithSubsidiaries(3)
                         .WithSubsidiariesClosedLoopRecycling(3),
                     CsoMemberBuilder.Large("100002")
+                        .WithIsClosedLoopRecycling()
                         .WithSubsidiaries(3)
                         .WithSubsidiariesClosedLoopRecycling(1),
                     CsoMemberBuilder.Large("100003").WithSubsidiaries(3)));
@@ -740,9 +743,123 @@ public class ClrPaymentScenarioTests : IntegrationTestBase
             applicationReferenceNumber = appRef,
             complianceSchemeMembers = new[]
             {
-                new { memberId = "100001", isClosedLoopRecycling = true, noOfSubsidiariesClosedLoopRecycling = 0 },
-                new { memberId = "100002", isClosedLoopRecycling = true, noOfSubsidiariesClosedLoopRecycling = 0 },
+                new { memberId = "100001", isClosedLoopRecycling = true, noOfSubsidiariesClosedLoopRecycling = 3 },
+                new { memberId = "100002", isClosedLoopRecycling = true, noOfSubsidiariesClosedLoopRecycling = 1 },
                 new { memberId = "100003", isClosedLoopRecycling = false, noOfSubsidiariesClosedLoopRecycling = 0 },
+            },
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "16")]
+    [Trait("Category", "AMCR-298")]
+    public async Task DirectProducer_6Subsidiaries_SubClr3_DisplaysPartialSubClrOnly_AndPostsProducerFeeRequest()
+    {
+        const int scenario = 16;
+        var submissionId = ClrPaymentScenarioIds.Scenario16;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int subsidiariesFeePence = 1295200;
+        const int subsidiaryClrFeePence = 509600;
+        const int netSubsidiaryFeePence = subsidiariesFeePence - subsidiaryClrFeePence;
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .AsDirectLargeProducer()
+                .WithApplicationReferenceNumber(appRef)
+                .WithProducerSubsidiaries(6)
+                .WithProducerClosedLoopRecycling(3, 0));
+
+        FacadeServer.SetupProducerRegistrationFee(
+            ProducerPaymentResponseBuilder.Default()
+                .WithProducerRegistrationFee(284200)
+                .WithProducerLateRegistrationFee(77200)
+                .WithTotalFee(1656600)
+                .WithOutstandingPayment(1656600)
+                .WithSubsidiariesFeeBreakdown(subsidiariesFeePence, subsidiaryClrFeePence, 3));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            page.SubTotal.Should().Be(16566.00m);
+            page.FindDirectProducerHoldingCompanyClrLine().Should().BeNull();
+            AssertDirectProducerSubsidiaryCompaniesLine(page, units: 6, amountPence: netSubsidiaryFeePence);
+            AssertDirectProducerSubsidiaryClrLine(page, units: 3, amountPence: subsidiaryClrFeePence);
+        }
+
+        FacadeServer.ShouldHavePostedProducerRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            isClosedLoopRecycling = false,
+            noOfHoldingCompaniesClosedLoopRecycling = 0,
+            noOfSubsidiariesClosedLoopRecycling = 3,
+        });
+    }
+
+    [Fact]
+    [Trait("Scenario", "17")]
+    [Trait("Category", "AMCR-298")]
+    public async Task Cso_2Members_SubClr2And3_DisplaysAggregatedClrFees_AndPostsSubClrInRequest()
+    {
+        const int scenario = 17;
+        var submissionId = ClrPaymentScenarioIds.Scenario17;
+        var appRef = ClrPaymentScenarioIds.AppRef(scenario);
+        const int hcClrFeePence = 254800;
+        const int memberOneSubsidiariesFeePence = 431700;
+        const int memberOneSubClrFeePence = 339700;
+        const int memberTwoSubsidiariesFeePence = 647600;
+        const int memberTwoSubClrFeePence = 509600;
+        const int netSubsidiaryFeePence =
+            (memberOneSubsidiariesFeePence - memberOneSubClrFeePence)
+            + (memberTwoSubsidiariesFeePence - memberTwoSubClrFeePence);
+
+        FacadeServer.SetupRegistrationSubmissionDetails(
+            RegistrationSubmissionDetailsBuilder.Default(submissionId)
+                .WithApplicationReferenceNumber(appRef)
+                .WithCsoMembers(
+                    CsoMemberBuilder.Large("100001")
+                        .WithIsClosedLoopRecycling()
+                        .WithSubsidiaries(2)
+                        .WithSubsidiariesClosedLoopRecycling(2),
+                    CsoMemberBuilder.Large("100002")
+                        .WithIsClosedLoopRecycling()
+                        .WithSubsidiaries(3)
+                        .WithSubsidiariesClosedLoopRecycling(3)));
+
+        FacadeServer.SetupComplianceSchemeRegistrationFee(
+            CompliancePaymentResponseBuilder.Default()
+                .WithComplianceSchemeRegistrationFee(284200)
+                .WithTotalFee(3000000)
+                .WithMembers(
+                    BuildCsoMemberWithSubsidiaryClr(
+                        "100001",
+                        hcClrFeePence,
+                        memberOneSubsidiariesFeePence,
+                        memberOneSubClrFeePence,
+                        2),
+                    BuildCsoMemberWithSubsidiaryClr(
+                        "100002",
+                        hcClrFeePence,
+                        memberTwoSubsidiariesFeePence,
+                        memberTwoSubClrFeePence,
+                        3)));
+
+        var page = await LoadDetailsPage(submissionId);
+
+        using (new AssertionScope())
+        {
+            AssertCsoHcClrLine(page, units: 2, amountPence: hcClrFeePence * 2);
+            AssertCsoSubsidiaryCompaniesLine(page, units: 5, amountPence: netSubsidiaryFeePence);
+            AssertCsoSubsidiaryClrLine(page, units: 5, amountPence: memberOneSubClrFeePence + memberTwoSubClrFeePence);
+        }
+
+        FacadeServer.ShouldHavePostedComplianceSchemeRegistrationFee(new
+        {
+            applicationReferenceNumber = appRef,
+            complianceSchemeMembers = new[]
+            {
+                new { memberId = "100001", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1, noOfSubsidiariesClosedLoopRecycling = 2 },
+                new { memberId = "100002", isClosedLoopRecycling = true, noOfHoldingCompaniesClosedLoopRecycling = 1, noOfSubsidiariesClosedLoopRecycling = 3 },
             },
         });
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/AMCR-298

**What**
Fixes incorrect closed-loop recycling (CLR) and subsidiary CLR fee calculation for CSO compliance scheme payment details.
Payment request mapping now uses per-member `IsClosedLoopRecycling` from facade csoJson for holding-company CLR, instead of applying an organisation-level HC CLR count to the first N members by index.
Derives `NoOfHoldingCompaniesClosedLoopRecycling` as 1 or 0 from each member's `IsClosedLoopRecycling` flag for the payment API request.
Passes per-member `NumberOfSubsidiariesClosedLoopRecycling` for large CSO members (previously hardcoded to 0 in the payment request).
Adds `IsClosedLoopRecycling` to `CsoMembershipDetailsDto` and updates the implicit operator to map HC CLR from the member bool rather than `NumberOfHoldingCompaniesClosedLoopRecycling`.
Removes `IsHoldingCompanyClosedLoopRecyclingMember` index-based logic and the dependency on the first member's org-level HC CLR count.
Updates unit and integration tests to cover per-member HC CLR flags, subsidiary CLR counts in payment requests, and mixed CSO CLR scenarios.

**Why**
For CSO submissions with multiple holding companies and subsidiaries, the payment details view sent incorrect CLR data to the payment API. HC CLR was derived from an organisation-level count and applied to members by position, which did not match the per-member CLR flags in csoJson. Subsidiary CLR counts were never sent, so subsidiary CLR fees were missing from the calculated total.
With epr-common-data-api and epr-regulator-service-facade AMCR-298 changes providing `IsClosedLoopRecycling` and `NumberOfSubsidiariesClosedLoopRecycling` per CSO member, the regulator frontend must map those member-level values directly into the payment request so fees match what was registered.

**Depends on**
epr-regulator-service-facade — AMCR-298 (deserialise `IsClosedLoopRecycling` and `NumberOfSubsidiariesClosedLoopRecycling` / `NumberOfSubsidiariesOnlineMarketPlace` from csoJson)
epr-common-data-api — AMCR-298/CLR-for-subsidiaries @ 56c799e (uses `NumberOfSubsidiariesClosedLoopRecycling`, not `NumberOfSubsidiariesAsClosedLoop`)
